### PR TITLE
Disable Raspberry Pi Analytics

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,7 +3,7 @@
 
 cmake_minimum_required(VERSION 3.9.4)
 OPTION (ENABLE_CHECK_VERSION "Check for version updates" ON)
-OPTION (ENABLE_TELEMETRY "Enable sending telemetry" ON)
+OPTION (ENABLE_TELEMETRY "Enable sending telemetry" OFF)
 OPTION (DRIVELIST_FILTER_SYSTEM_DRIVES "Filter System drives from displayed drives" ON)
 
 project(rpi-imager LANGUAGES CXX C)

--- a/src/OptionsPopup.qml
+++ b/src/OptionsPopup.qml
@@ -393,10 +393,12 @@ Window {
                                 id: chkEject
                                 text: qsTr("Eject media when finished")
                             }
+                            /*
                             ImCheckBox {
                                 id: chkTelemtry
                                 text: qsTr("Enable telemetry")
                             }
+                            */
                         }
                     }
                 }
@@ -462,7 +464,7 @@ Window {
 
     function initialize() {
         chkBeep.checked = imageWriter.getBoolSetting("beep")
-        chkTelemtry.checked = imageWriter.getBoolSetting("telemetry")
+        // chkTelemtry.checked = imageWriter.getBoolSetting("telemetry")
         chkEject.checked = imageWriter.getBoolSetting("eject")
         var settings = imageWriter.getSavedCustomizationSettings()
         fieldTimezone.model = imageWriter.getTimezoneList()
@@ -861,7 +863,7 @@ Window {
 
         imageWriter.setSetting("beep", chkBeep.checked)
         imageWriter.setSetting("eject", chkEject.checked)
-        imageWriter.setSetting("telemetry", chkTelemtry.checked)
+        imageWriter.setSetting("telemetry", false) // chkTelemtry.checked)
 
         if (chkHostname.checked || chkSetUser.checked || chkSSH.checked || chkWifi.checked || chkLocale.checked) {
             /* OS customization to be applied. */

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -264,7 +264,7 @@ int main(int argc, char *argv[])
         }
         else if (args[i] == "--help")
         {
-            cerr << args[0] << " [--debug] [--version] [--repo <repository URL>] [--qm <custom qm translation file>] [--disable-telemetry] [<image file to write>]" << endl;
+            cerr << args[0] << " [--debug] [--version] [--repo <repository URL>] [--qm <custom qm translation file>] " << /*"[--disable-telemetry]" <<*/ "[<image file to write>]" << endl;
             cerr << "-OR- " << args[0] << " --cli [--disable-verify] [--sha256 <expected hash>] [--debug] [--quiet] <image file to write> <destination drive device>" << endl;
             return 0;
         }
@@ -274,6 +274,7 @@ int main(int argc, char *argv[])
             cerr << "Repository: " << imageWriter.constantOsListUrl().toString() << endl;
             return 0;
         }
+        /*
         else if (args[i] == "--disable-telemetry")
         {
             cerr << "Disabled telemetry" << endl;
@@ -286,11 +287,16 @@ int main(int argc, char *argv[])
             settings.remove("telemetry");
             settings.sync();
         }
+        */
         else
         {
             cerr << "Ignoring unknown argument: " << args[i] << endl;
         }
     }
+
+    // for now, make sure telemetry is always disabled
+    settings.setValue("telemetry", false);
+    settings.sync();
 
     QTranslator *translator = new QTranslator;
     if (customQm.isEmpty())


### PR DESCRIPTION
This PR:
- sets the default value for telemetry compiler definition to false
- comments out the code in main.cpp that presents enable telemetry as a cli option
- comments out the code in main.cpp that parses disable and enable telemetry args
- adds a small bit of code to always add telemetry false to the settings
- comments out the code in options qml that presents telemetry checkbox
- is intended to close #14 

