### PR TITLE
Always displays options popup

### DIFF
--- a/src/OptionsPopup.qml
+++ b/src/OptionsPopup.qml
@@ -18,6 +18,7 @@ Window {
     minimumHeight: 125
     height: Math.min(750, cl.implicitHeight)
     title: qsTr("OS Customization")
+    modality: Qt.WindowModal
     
     color: UnColors.darkGray
     Material.theme: Material.Dark
@@ -35,6 +36,7 @@ Window {
     property string cloudinitnetwork
 
     signal saveSettingsSignal(var settings)
+    signal continueSignal()
 
     ColumnLayout {
         id: cl
@@ -453,6 +455,7 @@ Window {
                     applySettings()
                     saveSettings()
                     popup.close()
+                    continueSignal()
                 }
             }
 

--- a/src/main.qml
+++ b/src/main.qml
@@ -43,14 +43,6 @@ ApplicationWindow {
         }
     }
 
-    Shortcut {
-        sequences: ["Shift+Ctrl+X", "Shift+Meta+X"]
-        context: Qt.ApplicationShortcut
-        onActivated: {
-            optionspopup.openPopup()
-        }
-    }
-
     ColumnLayout {
         id: bg
         spacing: 0
@@ -302,10 +294,7 @@ ApplicationWindow {
                                 return
                             }
 
-                            if (!optionspopup.visible) {
-                                optionspopup.openPopup()
-                            } 
-                            confirmwritepopup.askForConfirmation()
+                            optionspopup.openPopup()
                             
                         }
                     }
@@ -1288,6 +1277,9 @@ ApplicationWindow {
         id: optionspopup
         onSaveSettingsSignal: {
             imageWriter.setSavedCustomizationSettings(settings)
+        }
+        onContinueSignal: {
+            confirmwritepopup.askForConfirmation()
         }
     }
 

--- a/src/main.qml
+++ b/src/main.qml
@@ -302,11 +302,11 @@ ApplicationWindow {
                                 return
                             }
 
-                            if (!optionspopup.visible && imageWriter.imageSupportsCustomization()) {
-                                usesavedsettingspopup.openPopup()
-                            } else {
-                                confirmwritepopup.askForConfirmation()
-                            }
+                            if (!optionspopup.visible) {
+                                optionspopup.openPopup()
+                            } 
+                            confirmwritepopup.askForConfirmation()
+                            
                         }
                     }
                 }
@@ -1288,32 +1288,6 @@ ApplicationWindow {
         id: optionspopup
         onSaveSettingsSignal: {
             imageWriter.setSavedCustomizationSettings(settings)
-            usesavedsettingspopup.hasSavedSettings = true
-        }
-    }
-
-    UseSavedSettingsPopup {
-        id: usesavedsettingspopup
-        onYes: {
-            optionspopup.initialize()
-            optionspopup.applySettings()
-            confirmwritepopup.askForConfirmation()
-        }
-        onNo: {
-            imageWriter.setImageCustomization("", "", "", "", "")
-            confirmwritepopup.askForConfirmation()
-        }
-        onNoClearSettings: {
-            hasSavedSettings = false
-            optionspopup.clearCustomizationFields()
-            imageWriter.clearSavedCustomizationSettings()
-            confirmwritepopup.askForConfirmation()
-        }
-        onEditSettings: {
-            optionspopup.openPopup()
-        }
-        onCloseSettings: {
-            optionspopup.close()
         }
     }
 

--- a/src/qml.qrc
+++ b/src/qml.qrc
@@ -26,7 +26,6 @@
         <file>OptionsPopup.qml</file>
         <file>countries.txt</file>
         <file>timezones.txt</file>
-        <file>UseSavedSettingsPopup.qml</file>
         <file>icons/ic_info_16px.png</file>
         <file>icons/ic_info_12px.png</file>
         <file>keymap-layouts.txt</file>


### PR DESCRIPTION
This PR:
- removes the "use saved settings popup" from main.qml
- changes the onClicked behavior of the next button to display the options popup instead
- is intended to close #4 