### PR TITLE
PID/VID Hex Strings on Mac

### DIFF
--- a/src/dependencies/drivelist/src/darwin/list.mm
+++ b/src/dependencies/drivelist/src/darwin/list.mm
@@ -138,10 +138,10 @@ void GetDeviceVidPidSerialNumber(const std::string& diskBsdName, DeviceDescripto
             s = (NSString *) serialNumberAsCFTypeRef;
             device_descriptor->serialNumber = std::string([s UTF8String]);
             NSNumber * n = (NSNumber *) vendorIdAsCFTypeRef;
-            s = [NSString stringWithFormat:@"%X", [n intValue]];
+            s = [NSString stringWithFormat:@"%04X", [n intValue]];
             device_descriptor->vid = std::string([s UTF8String]);
             n = (NSNumber *) productIdAsCFTypeRef;
-            s = [NSString stringWithFormat:@"%X", [n intValue]];
+            s = [NSString stringWithFormat:@"%04X", [n intValue]];
             device_descriptor->pid = std::string([s UTF8String]);
           }
           if(serialNumberAsCFTypeRef) CFRelease(serialNumberAsCFTypeRef);


### PR DESCRIPTION
- PID/VID are decimal ints on Mac, so they need to be zero padded to 4 digits for the GUID