### PR TITLE
use `#!/usr/bin/env bash` for portability

### DIFF
--- a/src/unraid/make_bootable_linux
+++ b/src/unraid/make_bootable_linux
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ################################################################################
 #      This file is ported from makebootable_mac used for the creation
@@ -97,4 +97,3 @@ sudo /tmp/UNRAID/syslinux/make_bootable_linux.sh $TARGET
 # clean up
 rm -rf /tmp/UNRAID/syslinux
 rmdir /tmp/UNRAID &>/dev/null
-

--- a/src/unraid/syslinux/make_bootable_linux.sh
+++ b/src/unraid/syslinux/make_bootable_linux.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ################################################################################
 #      This file is ported from makebootable_mac used for the creation


### PR DESCRIPTION
The make bootable scripts didn't work on my machine, because not all linux distros put `bash` in `/bin`.

I believe all distros do put `env` in `/usr/bin/`, so scripts should use `#!/usr/bin/env bash` rather than `#!/bin/bash`

for example:

```
$ /bin/bash
bash: /bin/bash: No such file or directory
$ whereis bash
bash: /nix/store/b3a27w8y60vpg3v95rp4q101gypfp384-user-environment/bin/bash /nix/store/8yrxzn21hwlcngfgkcr2xnrjk726sl9n-system-path/bin/bash
$ cat /etc/os-release | grep PRETTY_NAME=
PRETTY_NAME="NixOS 25.11 (Xantusia)"
```

Reference: http://stackoverflow.com/questions/16365130/ddg#16365367

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved portability of scripts by updating the shebang line to use a more flexible environment path for Bash.
  * Minor formatting update by removing a trailing blank line in one script.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->