### PR TITLE
feat(gui): allow selecting blacklisted drives & add info tooltip

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -2,9 +2,9 @@ name: Build MacOS
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
@@ -19,16 +19,65 @@ jobs:
         working-directory: src
 
     steps:
-    - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
-    - name: Install Qt
-      uses: jurplel/install-qt-action@v3
+      # Use Cmake < 4.0
+      - name: Setup CMake 3.31
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: "3.31.x"
 
-    - name: Configure CMake
-      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
-      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+      # Use Qt 5, not Qt 6
+      - name: Install Qt 5
+        run: |
+          brew update
+          brew install qt@5
 
-    - name: Build
-      # Build your program with the given configuration
-      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+      - name: Configure CMake
+        run: cmake -S . -B ../build -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} -DCMAKE_PREFIX_PATH="$(brew --prefix qt@5)"
+
+      - name: Build
+        run: cmake --build ../build --config ${{ env.BUILD_TYPE }}
+
+      # 5) Ad-hoc code sign (for CI purposes only)
+      - name: Ad-hoc Code Sign .app
+        run: |
+          CAPP="../build/unraid-usb-creator.app"
+          codesign --remove-signature "$CAPP"
+          codesign --force --deep --sign - "$CAPP"
+
+      # 6) Remove quarantine attribute
+      - name: Remove quarantine attribute
+        run: sudo xattr -rc ../build/unraid-usb-creator.app
+
+      # 7) Install Homebrew create-dmg (shell‐script version)
+      - name: Install create-dmg
+        run: |
+          brew update
+          brew install create-dmg
+
+      # 8) Package the signed .app into a DMG that has "drag to Applications"
+      - name: Create DMG with drag-to-Applications UI
+        run: |
+          # Make sure there's a Releases/ folder in the repo root
+          mkdir -p "${{ github.workspace }}/Releases"
+
+          # Create a “drag-to-Applications” DMG:
+          create-dmg \
+            --volname "Unraid Installer" \
+            --volicon "${{ github.workspace }}/src/icons/unraid.icns" \
+            --background "${{ github.workspace }}/src/icons/UN-logotype-gradient.png" \
+            --window-pos 200 120 \
+            --window-size 800 400 \
+            --icon "unraid-usb-creator.app" 200 190 \
+            --hide-extension "unraid-usb-creator.app" \
+            --app-drop-link 600 185 \
+            "${{ github.workspace }}/Releases/unraid-usb-creator.dmg" \
+            "${{ github.workspace }}/build/unraid-usb-creator.app"
+
+      - name: Upload Mac DMG
+        uses: actions/upload-artifact@v4
+        with:
+          name: UnraidInstallerMacOS
+          path: Releases/unraid-usb-creator.dmg
+# Might need to use `codesign` to sign the app and everything related to that

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -13,7 +13,7 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    container: ghcr.io/${{ github.repository }}/usb-creator-mxe:latest
+    container: ghcr.io/unraid/usb-creator-next/usb-creator-mxe:latest
 
     steps:
     - name: Checkout code

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-build**
+build/**
+
 .vscode
 obj-**
 debian/rpi-imager/**
@@ -14,3 +15,7 @@ Releases
 
 *.DS_Store
 
+
+# QT Creator
+/src/build/**
+.qtcreator**

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,11 @@ debian/.debhelper**
 debian/files
 debian/*.substvars
 debian/debhelper**.DS_Store
+
+
+# For macOS .dmg creation in workflow
+Releases 
+*.dmg
+
+*.DS_Store
+

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -267,17 +267,6 @@ elseif(APPLE)
     set(ENABLE_TAR OFF CACHE BOOL "")
     set(ENABLE_CPIO OFF CACHE BOOL "")
     set(ENABLE_CAT OFF CACHE BOOL "")
-
-
-    # Prevents build failure in Debug builds (see LIBARCHIVE_FIX_001 in docs)
-    if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-      # disable that warning (and make it non-fatal)
-      add_compile_options(
-        -Wno-single-bit-bitfield-constant-conversion
-        -Wno-error=single-bit-bitfield-constant-conversion
-      )
-    endif()
-
     add_subdirectory(dependencies/libarchive-3.6.2)
     # Disable shared libarchive (we only want static)
     set_target_properties(archive PROPERTIES EXCLUDE_FROM_ALL 1)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -267,6 +267,17 @@ elseif(APPLE)
     set(ENABLE_TAR OFF CACHE BOOL "")
     set(ENABLE_CPIO OFF CACHE BOOL "")
     set(ENABLE_CAT OFF CACHE BOOL "")
+
+
+    # Prevents build failure in Debug builds (see LIBARCHIVE_FIX_001 in docs)
+    if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+      # disable that warning (and make it non-fatal)
+      add_compile_options(
+        -Wno-single-bit-bitfield-constant-conversion
+        -Wno-error=single-bit-bitfield-constant-conversion
+      )
+    endif()
+
     add_subdirectory(dependencies/libarchive-3.6.2)
     # Disable shared libarchive (we only want static)
     set_target_properties(archive PROPERTIES EXCLUDE_FROM_ALL 1)

--- a/src/main.qml
+++ b/src/main.qml
@@ -1350,7 +1350,7 @@ ApplicationWindow {
                                 opacity: enabled ? 1.0 : 0.3
                                 text: {
                                     if (guid != "") {
-                                        return guidValid ? "GUID: %1".arg(guid).arg(guid)
+                                        return guidValid ? "GUID: %1".arg(guid)
                                                          : "GUID: %1 <font color='red'>[BLACKLISTED]</font>".arg(guid)
                                     } else {
                                         return "<font color='red'>[MISSING GUID - Choose Another Flash Device]</font>"
@@ -1372,7 +1372,7 @@ ApplicationWindow {
                                 visible: guid != "" && !guidValid
                                 hoverEnabled: true
                                 ToolTip.visible: hovered
-                                ToolTip.text: "This USB device is blacklisted. You can use it to install Unraid on an internal drive, but you cannot use it to run Unraid."
+                                ToolTip.text: "This USB device is blacklisted. You may not be able to use this device to get an Unraid license or trial."
                               }
 
                         }
@@ -1981,12 +1981,6 @@ ApplicationWindow {
             }
         } else {
             imageWriter.setSrc(d.url, d.image_download_size, d.extract_size, typeof(d.extract_sha256) != "undefined" ? d.extract_sha256 : "", typeof(d.contains_multiple_files) != "undefined" ? d.contains_multiple_files : false, ospopup.categorySelected, d.name, typeof(d.init_format) != "undefined" ? d.init_format : "")
-            if(imageWriter.getInitFormat() === "UNRAID" && imageWriter.getDstDevice() !== "" && !imageWriter.getDstGuidValid()) {
-                onError(qsTr("Selected device cannot be used to create an Unraid USB due to its invalid GUID."))
-                writebutton.enabled = false
-                imageWriter.setDst("", false)
-                dstbutton.text = qsTr("CHOOSE STORAGE")
-            }
             osbutton.text = d.name
             ospopup.close()
             osswipeview.decrementCurrentIndex()
@@ -1999,12 +1993,6 @@ ApplicationWindow {
     function selectDstItem(d) {
         if (d.isReadOnly) {
             onError(qsTr("SD card is write protected.<br>Push the lock switch on the left side of the card upwards, and try again."))
-            return
-        }
-
-        if(imageWriter.getInitFormat() === "UNRAID" && !d.guidValid) {
-            onError(qsTr("Selected device cannot be used to create an Unraid USB due to its invalid GUID."))
-            writebutton.enabled = false
             return
         }
 

--- a/src/main.qml
+++ b/src/main.qml
@@ -18,8 +18,8 @@ ApplicationWindow {
     height: imageWriter.isEmbeddedMode() ? -1 : 465
     minimumWidth: imageWriter.isEmbeddedMode() ? -1 : 680
     minimumHeight: imageWriter.isEmbeddedMode() ? -1 : 465
-    
-    
+
+
     color: UnColors.darkGray
 
     title: qsTr("Unraid USB Creator v%1").arg(imageWriter.constantVersion())
@@ -121,7 +121,7 @@ ApplicationWindow {
                 fillMode: Image.PreserveAspectFit
             }
         }
-        
+
         Rectangle {
             color: UnColors.orange
             implicitWidth: window.width
@@ -351,7 +351,7 @@ ApplicationWindow {
                             } else {
                                 confirmwritepopup.askForConfirmation()
                             }
-                            
+
                         }
                     }
                 }
@@ -564,7 +564,7 @@ ApplicationWindow {
             Layout.column: 2
             Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
             spacing: 0
-	
+
             Text {
                 color: UnColors.orange
                 text: qsTr("Select Language")
@@ -605,7 +605,7 @@ ApplicationWindow {
         padding: 0
         closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
         property string hwselected: ""
-        
+
         background: Rectangle {
             color: UnColors.darkGray
             border.color: UnColors.mediumGray
@@ -714,7 +714,7 @@ ApplicationWindow {
         padding: 0
         closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
         property string categorySelected : ""
-        
+
         background: Rectangle {
             color: UnColors.darkGray
             border.color: UnColors.mediumGray
@@ -1243,7 +1243,6 @@ ApplicationWindow {
             property string guid: model.guid
             property bool guidValid: model.guidValid
 
-            enabled: guidValid
 
             Rectangle {
                id: dstbgrect
@@ -1253,6 +1252,25 @@ ApplicationWindow {
                property bool mouseOver: false
                border.color: UnColors.mediumGray
 
+            }
+            MouseArea {
+                anchors.fill: parent
+
+                cursorShape: Qt.PointingHandCursor
+                hoverEnabled: true
+
+
+                onEntered: {
+                    dstbgrect.mouseOver = true
+                }
+
+                onExited: {
+                    dstbgrect.mouseOver = false
+                }
+
+                onClicked: {
+                    selectDstItem(model)
+                }
             }
             Rectangle {
                id: dstborderrect
@@ -1278,8 +1296,10 @@ ApplicationWindow {
                 }
                 Column {
                     width: parent.parent.width-64
+
                     ColumnLayout {
                         spacing: 1
+
                         Text {
                             textFormat: Text.StyledText
                             height: parent.parent.parent.parent.height / 3
@@ -1315,46 +1335,57 @@ ApplicationWindow {
                             opacity: enabled ? 1.0 : 0.3
                             anchors.topMargin: 10
                         }
-                        Text {
-                            textFormat: Text.StyledText
-                            height: parent.parent.parent.parent.height / 3
-                            //verticalAlignment: Text.AlignVCenter
-                            font.family: roboto.name
-                            font.pixelSize: 12
-                            text: {
-                                var txt = ""
-                                if(guid != "") {
-                                    txt += "GUID: %1".arg(guid)
-                                    if(!guidValid)  txt += " <font color='red'>[BLACKLISTED - Choose Another Flash Device]</font>"
-                                } else {
-                                    txt += "<font color='red'>[MISSING GUID - Choose Another Flash Device]</font>"
+
+
+                        RowLayout {
+                            spacing: 4
+                            Layout.alignment: Qt.AlignVCenter
+
+                            Text {
+                                textFormat: Text.StyledText
+                                font.family: roboto.name
+                                font.pixelSize: 12
+                                Layout.alignment: Qt.AlignVCenter
+                                color: dstbgrect.mouseOver ? UnColors.darkGray : "white"
+                                opacity: enabled ? 1.0 : 0.3
+                                text: {
+                                    if (guid != "") {
+                                        return guidValid ? "GUID: %1".arg(guid).arg(guid)
+                                                         : "GUID: %1 <font color='red'>[BLACKLISTED]</font>".arg(guid)
+                                    } else {
+                                        return "<font color='red'>[MISSING GUID - Choose Another Flash Device]</font>"
+                                    }
                                 }
-                                return txt;
+
                             }
-                            color: dstbgrect.mouseOver ? UnColors.darkGray : "white"
-                            opacity: enabled ? 1.0 : 0.3
+
+
+                            ToolButton {
+                                icon.source: dstbgrect.mouseOver ? "unraid/icons/info_dark_gray.svg": "unraid/icons/info_orange.svg"
+                                icon.color: "transparent"
+                                icon.width: 16
+                                icon.height: 16
+                                Layout.alignment: Qt.AlignVCenter
+                                padding: 0
+                                implicitWidth:  icon.width
+                                implicitHeight: icon.height
+                                visible: guid != "" && !guidValid
+                                hoverEnabled: true
+                                ToolTip.visible: hovered
+                                ToolTip.text: "This USB device is blacklisted. You can use it to install Unraid on an internal drive, but you cannot use it to run Unraid."
+                              }
+
                         }
+
                     }
                 }
+
+
+
+
             }
 
-            MouseArea {
-                anchors.fill: parent
-                cursorShape: Qt.PointingHandCursor
-                hoverEnabled: true
 
-                onEntered: {
-                    dstbgrect.mouseOver = true
-                }
-
-                onExited: {
-                    dstbgrect.mouseOver = false
-                }
-
-                onClicked: {
-                    selectDstItem(model)
-                }
-            }
         }
     }
 
@@ -1367,7 +1398,7 @@ ApplicationWindow {
             imageWriter.openUrl("https://docs.unraid.net/go/quick-install-guide")
         }
     }
-    
+
     MsgPopup {
         id: infopopup
         x: 50


### PR DESCRIPTION
## What’s Changed
- Always allow drive selection, even if its GUID is in the blacklist
- Add an “info” hover icon that explains the risks of using a blacklisted GUID

## Why & How
1. **Drive selection override**
We want users to be able to force-select any drive, regardless of GUID blacklist status.

2. **Hover-tooltip**
A small “ℹ️” icon appears next to blacklisted entries. Hovering it shows a pop-up explaining what a blacklisted GUID means.

## Technical Details
- **MouseArea event collision**
The new tooltip’s `MouseArea` and the existing drive-selection `MouseArea` both occupied the same region. In QML, only one `MouseArea` handles clicks in an overlapped area, and simply tweaking a `z` value didn’t help because:

    - `z` **only affects stacking within the same parent item**, and these two areas lived under different parents
    - QML delivers mouse events to the topmost item in declaration order when `z` is equal

- **Solution**
    I moved the drive-selection `MouseArea` to be declared before the tooltip icon’s `MouseArea`. That ensures the selection area sits “on top” in the stacking order and receives clicks first, while the icon still correctly responds to hovers.

## Next Steps
- Add localized translations for the tooltip text in a follow-up PR
- Add documentation in follow-up PR
- (Optionally) Add a quick unit/UI test to verify that clicking through the tooltip still selects the drive