### PR TITLE
chore(build): add signing & notarization to github action workflow for macOS

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -5,7 +5,7 @@ on:
     branches: ["main"]
   pull_request:
     branches: ["main"]
-
+  workflow_dispatch: {}
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: Release
@@ -49,7 +49,7 @@ jobs:
           chmod +x ../scripts/setup-keychain-mac.sh
           ../scripts/setup-keychain-mac.sh
 
-       # Code sign the .app with proper certificate
+        # Code sign the .app with proper certificate
       - name: Code Sign .app
         env:
           APPLE_SIGNING_KEY_ID: ${{ secrets.APPLE_SIGNING_KEY_ID }}
@@ -61,7 +61,6 @@ jobs:
       # Remove quarantine attribute
       - name: Remove quarantine attribute
         run: sudo xattr -rc ../build/unraid-usb-creator.app
-
 
       # 7) Install Homebrew create-dmg (shell‐script version)
       - name: Install create-dmg
@@ -87,7 +86,6 @@ jobs:
             --app-drop-link 600 185 \
             "${{ github.workspace }}/Releases/unraid-usb-creator.dmg" \
             "${{ github.workspace }}/build/unraid-usb-creator.app"
-
 
       # Notarize the DMG
       - name: Notarize DMG

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -39,16 +39,29 @@ jobs:
       - name: Build
         run: cmake --build ../build --config ${{ env.BUILD_TYPE }}
 
-      # 5) Ad-hoc code sign (for CI purposes only)
-      - name: Ad-hoc Code Sign .app
+      # Setup keychain and certificates for signing & unlock keychain
+      - name: Setup Keychain and Certificates
+        env:
+          APPLE_BUILD_CERTIFICATE_BASE64: ${{ secrets.APPLE_BUILD_CERTIFICATE_BASE64 }}
+          APPLE_BUILD_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_BUILD_CERTIFICATE_PASSWORD }}
+          APPLE_KEYCHAIN_PASSWORD: ${{ secrets.APPLE_KEYCHAIN_PASSWORD }}
+        run: |
+          chmod +x ../scripts/setup-keychain-mac.sh
+          ../scripts/setup-keychain-mac.sh
+
+       # Code sign the .app with proper certificate
+      - name: Code Sign .app
+        env:
+          APPLE_SIGNING_KEY_ID: ${{ secrets.APPLE_SIGNING_KEY_ID }}
+          APPLE_KEYCHAIN_PASSWORD: ${{ secrets.APPLE_KEYCHAIN_PASSWORD }}
         run: |
           CAPP="../build/unraid-usb-creator.app"
-          codesign --remove-signature "$CAPP"
-          codesign --force --deep --sign - "$CAPP"
+          codesign --deep --force --verify --verbose --sign "$APPLE_SIGNING_KEY_ID" --options runtime "$CAPP"
 
-      # 6) Remove quarantine attribute
+      # Remove quarantine attribute
       - name: Remove quarantine attribute
         run: sudo xattr -rc ../build/unraid-usb-creator.app
+
 
       # 7) Install Homebrew create-dmg (shell‐script version)
       - name: Install create-dmg
@@ -75,9 +88,20 @@ jobs:
             "${{ github.workspace }}/Releases/unraid-usb-creator.dmg" \
             "${{ github.workspace }}/build/unraid-usb-creator.app"
 
+
+      # Notarize the DMG
+      - name: Notarize DMG
+        env:
+          APPLE_EMAIL_ADDRESS: ${{ secrets.APPLE_EMAIL_ADDRESS }}
+          APPLE_APP_PASSWORD: ${{ secrets.APPLE_APP_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          cd "${{ github.workspace }}/Releases"
+          xcrun notarytool submit "unraid-usb-creator.dmg" --apple-id "$APPLE_EMAIL_ADDRESS" --password "$APPLE_APP_PASSWORD" --team-id "$APPLE_TEAM_ID" --wait
+          xcrun stapler staple "unraid-usb-creator.dmg"
+
       - name: Upload Mac DMG
         uses: actions/upload-artifact@v4
         with:
           name: UnraidInstallerMacOS
           path: Releases/unraid-usb-creator.dmg
-# Might need to use `codesign` to sign the app and everything related to that

--- a/scripts/setup-keychain-mac.sh
+++ b/scripts/setup-keychain-mac.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# create variables
+CERTIFICATE_PATH=$RUNNER_TEMP/build_certificate.p12
+KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
+
+# import certificate and provisioning profile from secrets
+echo -n "$APPLE_BUILD_CERTIFICATE_BASE64" | base64 --decode -o $CERTIFICATE_PATH
+
+# create keychain
+security create-keychain -p "$APPLE_KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
+security unlock-keychain -p "$APPLE_KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+
+# import certificate to keychain
+security import $CERTIFICATE_PATH -P "$APPLE_BUILD_CERTIFICATE_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
+security set-key-partition-list -S apple-tool:,apple: -k "$APPLE_KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+security list-keychain -d user -s $KEYCHAIN_PATH
+
+
+echo "Keychain setup completed successfully"

--- a/scripts/sign-mac.sh
+++ b/scripts/sign-mac.sh
@@ -1,0 +1,13 @@
+#! /bin/bash
+cd USB_CREATOR_DIR
+codesign --deep --force --verify --verbose --sign "$APPLE_SIGNING_KEY_ID" --options runtime unraid-usb-creator.app
+mv unraid-usb-creator.app "Unraid USB Creator.app"
+create-dmg \
+--icon "Unraid USB Creator.app" 100 100 \
+--app-drop-link 300 100 \
+--window-pos 200 120 \
+--window-size 600 400 \
+"Unraid USB Creator.dmg" "Unraid USB Creator.app"
+
+xcrun notarytool submit "Unraid USB Creator.dmg"  --apple-id "$APPLE_EMAIL_ADDRESS" --password "$APPLE_APP_PASSWORD" --team-id "$APPLE_TEAM_ID" --wait
+xcrun stapler staple "Unraid USB Creator.dmg"


### PR DESCRIPTION
# Added Features
- Adds automated signing & notarization for macos workflow

# Changes Made
### 1. New Scripts Folder
Currently contains shell scripts for:
  - Setting up developer keychain on macOS
  - Signing, building dmg, and notarizing dmg for macOS
      - This script is not used in workflow, but kept in folder just in if anyone wants to sign, build, and notarize locally instead of using the workflows' artifact.
      
### 2. Updated macOS GitHub Action
- Changed `build-macos.yml` to use `setup-keychain-mac.sh` and then uses its own script for signing, creating the dmg, and notarizing. 
- Added workflow_dispatch

> [!NOTE]
> Scripts are from the following pull request: https://github.com/unraid/usb-creator-next/pull/50
