### PR TITLE
fix(ci): gate optional docs publication token

### DIFF
--- a/.github/workflows/e2e-qemu.yml
+++ b/.github/workflows/e2e-qemu.yml
@@ -95,8 +95,21 @@ jobs:
       # Never expose the cross-repository credential to pull-request code. A
       # manual run must also target main; selecting an arbitrary ref is not a
       # trusted publication boundary.
-      - name: Check out documentation repository
+      - name: Check documentation publication credential
+        id: docs-auth
         if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
+        env:
+          DOCS_REPO_TOKEN: ${{ secrets.DOCS_REPO_TOKEN }}
+        run: |
+          if [[ -n "$DOCS_REPO_TOKEN" ]]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "DOCS_REPO_TOKEN is not configured; retaining the documentation bundle as a workflow artifact."
+          fi
+
+      - name: Check out documentation repository
+        if: steps.docs-auth.outputs.available == 'true'
         uses: actions/checkout@v4
         with:
           repository: unraid/docs
@@ -105,7 +118,7 @@ jobs:
           token: ${{ secrets.DOCS_REPO_TOKEN }}
 
       - name: Open documentation screenshot PR when images changed
-        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
+        if: steps.docs-auth.outputs.available == 'true'
         env:
           GH_TOKEN: ${{ secrets.DOCS_REPO_TOKEN }}
           USB_CREATOR_CAPTURE_ID: ${{ github.sha }}-${{ github.run_id }}


### PR DESCRIPTION
## Summary
Keep trusted main-branch QEMU runs green when optional cross-repository documentation credentials are not configured, while always retaining accepted screenshots as workflow artifacts.

## Why This Exists
The first post-merge QEMU run completed the destructive USB write, verification, screenshot collation, and artifact uploads, then failed because `actions/checkout` received an empty `DOCS_REPO_TOKEN`. Cross-repository docs publication is optional; its missing credential should not invalidate the product test.

## Resolution
Probe the credential only inside a trusted push/main step, emit a non-secret availability output, and condition the docs checkout/publication steps on that output. Pull-request code never receives the credential.

## Reviewer Considerations
- The secret is scoped only to the trusted credential-check step.
- Missing credentials skip cross-repository publication but preserve both evidence artifacts.
- A configured credential retains the existing docs PR behavior.

## Behavior Changes
Main QEMU runs no longer fail after successful testing solely because optional docs publication is not configured.

## Verification
- `actionlint .github/workflows/e2e-qemu.yml`
- `git diff --check`

## Risk
Low; workflow-only conditional gating around an optional publication path.