### PR TITLE
fix(ci): use admin token for docs publication

### DIFF
--- a/.github/workflows/e2e-qemu.yml
+++ b/.github/workflows/e2e-qemu.yml
@@ -99,13 +99,13 @@ jobs:
         id: docs-auth
         if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
         env:
-          DOCS_REPO_TOKEN: ${{ secrets.DOCS_REPO_TOKEN }}
+          UNRAID_BOT_GITHUB_ADMIN_TOKEN: ${{ secrets.UNRAID_BOT_GITHUB_ADMIN_TOKEN }}
         run: |
-          if [[ -n "$DOCS_REPO_TOKEN" ]]; then
+          if [[ -n "$UNRAID_BOT_GITHUB_ADMIN_TOKEN" ]]; then
             echo "available=true" >> "$GITHUB_OUTPUT"
           else
             echo "available=false" >> "$GITHUB_OUTPUT"
-            echo "DOCS_REPO_TOKEN is not configured; retaining the documentation bundle as a workflow artifact."
+            echo "UNRAID_BOT_GITHUB_ADMIN_TOKEN is not configured; retaining the documentation bundle as a workflow artifact."
           fi
 
       - name: Check out documentation repository
@@ -115,11 +115,11 @@ jobs:
           repository: unraid/docs
           ref: main
           path: build/docs-publication
-          token: ${{ secrets.DOCS_REPO_TOKEN }}
+          token: ${{ secrets.UNRAID_BOT_GITHUB_ADMIN_TOKEN }}
 
       - name: Open documentation screenshot PR when images changed
         if: steps.docs-auth.outputs.available == 'true'
         env:
-          GH_TOKEN: ${{ secrets.DOCS_REPO_TOKEN }}
+          GH_TOKEN: ${{ secrets.UNRAID_BOT_GITHUB_ADMIN_TOKEN }}
           USB_CREATOR_CAPTURE_ID: ${{ github.sha }}-${{ github.run_id }}
         run: e2e/docs/publish.sh build/docs-bundle/current build/docs-publication


### PR DESCRIPTION
## Summary
The QEMU E2E workflow was still looking for the old `DOCS_REPO_TOKEN`; this wires trusted screenshot publication to the newly configured `UNRAID_BOT_GITHUB_ADMIN_TOKEN`.

## Why This Exists
A passing Creator walkthrough currently retains its accepted screenshots only as a workflow artifact because the credential check cannot see the newly added repository secret. As a result, the intended exact-replacement screenshot PR is never opened in `unraid/docs`.

## Resolution
Use `UNRAID_BOT_GITHUB_ADMIN_TOKEN` consistently for the trusted main-branch credential check, docs repository checkout, and GitHub CLI publication step. Pull-request code remains unable to access the secret.

## Reviewer Considerations
- Confirm the repository secret is named exactly `UNRAID_BOT_GITHUB_ADMIN_TOKEN` and has write access to `unraid/docs` pull-request branches.
- Publication remains restricted to pushes to trusted code and manual runs targeting `main`; ordinary pull-request runs do not receive the credential.

## Behavior Changes
Passing main-branch QEMU walkthroughs can now open or refresh the screenshot-only PR in `unraid/docs` when captures change.

## Implementation Summary
- Replace all workflow references to the legacy secret with `UNRAID_BOT_GITHUB_ADMIN_TOKEN`.
- Update the missing-credential diagnostic to name the configured secret accurately.

## Verification
- `git diff --check`
- `actionlint .github/workflows/e2e-qemu.yml`

## Risk
Low; the change only corrects the secret binding, while the existing trusted-event gates and publication behavior remain unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation publication authentication to use the current access credential.
  * Improved consistency across automated documentation publishing and repository access checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->