### PR TITLE
fix(ci): invoke docs publisher with bash

### DIFF
--- a/.github/workflows/e2e-qemu.yml
+++ b/.github/workflows/e2e-qemu.yml
@@ -122,4 +122,4 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.UNRAID_BOT_GITHUB_ADMIN_TOKEN }}
           USB_CREATOR_CAPTURE_ID: ${{ github.sha }}-${{ github.run_id }}
-        run: e2e/docs/publish.sh build/docs-bundle/current build/docs-publication
+        run: bash e2e/docs/publish.sh build/docs-bundle/current build/docs-publication


### PR DESCRIPTION
## Summary
Trusted screenshot publication reached the docs step but failed with exit 126; this invokes the checked-in publisher through Bash so its non-executable Git mode cannot block the workflow.

## Why This Exists
The first main-branch run with `UNRAID_BOT_GITHUB_ADMIN_TOKEN` successfully verified the credential and checked out `unraid/docs`, then failed before publication because `e2e/docs/publish.sh` is mode `100644`.

## Resolution
Invoke the script explicitly with Bash. This is portable across Git checkouts and makes the interpreter choice visible in the workflow without changing any publication boundary or credential handling.

## Reviewer Considerations
- This PR depends operationally on unraid/docs#522, which adds the docs-owned verified screenshot importer called by the publisher.
- The trusted-event secret gate remains unchanged.

## Behavior Changes
Successful trusted QEMU runs can proceed into screenshot import instead of stopping with permission denied.

## Implementation Summary
- Run `bash e2e/docs/publish.sh ...` in the publication step.

## Verification
- `bash -n e2e/docs/publish.sh`
- `actionlint .github/workflows/e2e-qemu.yml`
- `git diff --check`

## Risk
Low; only the invocation method changes.
