### PR TITLE
fix(ci): publish newly captured screenshots

### DIFF
--- a/e2e/docs/publish.sh
+++ b/e2e/docs/publish.sh
@@ -18,7 +18,7 @@ docs="$(cd "$docs" && pwd)"
 git -C "$docs" switch -C "$branch" origin/main
 (cd "$docs" && node scripts/import-usb-creator-flow.mjs "$bundle")
 
-if git -C "$docs" diff --quiet -- static/img/unraid-os/getting-started/create-unraid-usb; then
+if [[ -z "$(git -C "$docs" status --porcelain -- static/img/unraid-os/getting-started/create-unraid-usb)" ]]; then
   echo "USB Creator documentation screenshots are unchanged"
   exit 0
 fi


### PR DESCRIPTION
## Summary
The first verified screenshot import created untracked PNGs but the publisher only checked tracked diffs; this makes first-time captures open the intended docs PR.

## Why This Exists
Trusted main run 31110699137 imported five accepted screenshots successfully, then incorrectly printed “unchanged.” `git diff --quiet` ignores untracked files, so it cannot detect the initial population of the screenshot directory.

## Resolution
Use path-scoped `git status --porcelain`, which reports both untracked additions and tracked replacements/deletions while preserving the existing no-op behavior when the exact image set is unchanged.

## Reviewer Considerations
- The check remains confined to `static/img/unraid-os/getting-started/create-unraid-usb`.
- No credential, capture, or docs-content behavior changes.

## Behavior Changes
The first accepted screenshot set now creates a docs PR; subsequent unchanged runs remain no-ops.

## Implementation Summary
- Detect all working-tree changes in the screenshot publication path.

## Verification
- `bash -n e2e/docs/publish.sh`
- `git diff --check`
- Trusted run evidence: importer created five PNGs before the prior tracked-only check missed them.

## Risk
Low; this corrects change detection without expanding the staged path.
