### PR TITLE
fix(release): preserve AppImage executable bit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,9 @@ jobs:
           if ls release/*-v*.dmg >/dev/null 2>&1; then
             find release -name '*.dmg' ! -name '*-v*.dmg' -delete
           fi
+          # actions/download-artifact normalizes file permissions, so restore
+          # the executable bit before publishing AppImages to the release.
+          find release -type f -name '*.AppImage' -exec chmod +x {} +
           ls -lh release/
 
       - name: Create release


### PR DESCRIPTION
## Summary
Release artifacts were losing the AppImage executable bit; this restores it before GitHub Release upload so Ubuntu users can run the download directly.

## Why This Exists
The Linux build marks the AppImage executable, but `actions/download-artifact` normalizes permissions in the publish job. The resulting release asset could require a manual `chmod +x) before it would launch on Ubuntu.

## Resolution
The release collection step now applies `chmod +x` to every collected `.AppImage` after artifact download and before publication.

## Reviewer Considerations
- The permission fix is scoped to release assets and does not change the build artifact contents.
- Other installer types are unaffected.
- The fix is intentionally in the publish workflow because that is where permissions are lost.

## Behavior Changes
Published Linux AppImages are executable by default after download.

## Implementation Summary
- Updated `.github/workflows/release.yml` to restore the executable bit on collected AppImages.

## Verification
- `actionlint .github/workflows/release.yml`
- `git diff --check`

## Risk
Low; the change affects only file mode metadata for files already identified as AppImages.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * AppImage downloads published in releases now retain the correct executable permissions, allowing them to launch as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->