### PR TITLE
fix(macos): stop the post-write hang — background eject with live status

### DIFF
--- a/debian/rpi-imager-cli.install
+++ b/debian/rpi-imager-cli.install
@@ -7,3 +7,8 @@
 src/linux/icon/rpi-imager.svg /usr/share/icons/hicolor/scalable/apps/
 
 debian/com.raspberrypi.rpi-imager-cli.desktop /usr/share/applications/
+
+# Install udev rules granting unprivileged USB access to rpiboot/fastboot
+# devices. Without these a non-root user cannot open the device and it
+# silently never appears in the drive list.
+src/linux/99-rpiboot.rules /usr/lib/udev/rules.d/

--- a/debian/rpi-imager.install
+++ b/debian/rpi-imager.install
@@ -7,6 +7,11 @@
 # Install PolicyKit policy for privilege escalation
 debian/com.raspberrypi.rpi-imager.policy /usr/share/polkit-1/actions/
 
+# Install udev rules granting unprivileged USB access to rpiboot/fastboot
+# devices. Without these a non-root user cannot open the device and it
+# silently never appears in the storage list.
+src/linux/99-rpiboot.rules /usr/lib/udev/rules.d/
+
 src/linux/icon/rpi-imager.svg /usr/share/icons/hicolor/scalable/apps/
 
 debian/com.raspberrypi.rpi-imager.desktop /usr/share/applications/

--- a/src/devicewrapper.cpp
+++ b/src/devicewrapper.cpp
@@ -17,7 +17,16 @@ DeviceWrapper::DeviceWrapper(rpi_imager::FileOperations *file_ops, QObject *pare
 
 DeviceWrapper::~DeviceWrapper()
 {
-    sync();
+    /* sync() throws on a write or flush failure, and a destructor is implicitly
+       noexcept — letting that escape calls std::terminate(). A card reader that
+       disappeared mid-write is exactly the case that makes the final flush fail,
+       so kill the process there and the user loses the error dialog too. Callers
+       that need to know a flush failed call sync() explicitly. */
+    try {
+        sync();
+    } catch (const std::exception &err) {
+        qDebug() << "DeviceWrapper: sync() failed during destruction:" << err.what();
+    }
 }
 
 void DeviceWrapper::_seekToBlock(quint64 blockNr)

--- a/src/devicewrapper.cpp
+++ b/src/devicewrapper.cpp
@@ -59,12 +59,32 @@ void DeviceWrapper::sync()
 
         if (block->dirty)
         {
+            /* Force every preceding filesystem write to physical media BEFORE the
+             * MBR/partition table becomes visible. On USB card readers the bridge
+             * or card write-cache can reorder writes, so without this flush the MBR
+             * (block 0) can reach the media ahead of the FAT blocks written above.
+             * Windows then sees a partition whose filesystem is still incomplete and
+             * pops "You need to format the disk in drive X:" mid-write — especially
+             * when Explorer is already watching the drive. Flushing here guarantees
+             * the partition only appears once its contents are durably on media.
+             * (This is why the bug reproduces on real card readers but never on a
+             * virtual disk, which has no reordering write-cache.) A device that does
+             * not support flush returns success from Flush(), so this is a no-op there.
+             * Crash-safe: unlike disabling AutoMount, this touches no global OS state. */
+            auto flushResult = _file_ops->Flush();
+            if (flushResult != rpi_imager::FileError::kSuccess) {
+                throw std::runtime_error("Error flushing filesystem to device before writing MBR");
+            }
+
             _seekToBlock(0);
             auto result = _file_ops->WriteSequential(reinterpret_cast<const std::uint8_t*>(block->block), 4096);
             if (result != rpi_imager::FileError::kSuccess) {
                 throw std::runtime_error("Error writing MBR to device");
             }
             block->dirty = false;
+
+            /* And flush the MBR itself so the now-complete partition is durable. */
+            _file_ops->Flush();
         }
     }
 

--- a/src/downloadextractthread.cpp
+++ b/src/downloadextractthread.cpp
@@ -32,6 +32,13 @@
 #include <unistd.h>
 #endif
 
+#ifdef Q_OS_LINUX
+#include <sys/ioctl.h>
+#include <linux/fs.h>   // BLKRRPART
+#include <cerrno>
+#include <QFile>
+#endif
+
 using namespace std;
 
 // Ring buffer slot count is now determined dynamically by SystemMemoryManager
@@ -797,6 +804,44 @@ void DownloadExtractThread::extractMultiFileRun()
             fatpartition += "p1";
         else
             fatpartition += "1";
+
+        // UNRAID: the partition node for the freshly written table may not
+        // exist yet. The kernel re-reads the table when the last writer
+        // closes the whole-disk device, but the exclusive (O_EXCL) open used
+        // during formatting means that re-read can fail with EBUSY and only
+        // happen later — mounting immediately then dies with "special device
+        // does not exist". Wait for the node, and after a grace period ask
+        // the kernel for a re-read ourselves.
+        if (!QFile::exists(fatpartition))
+        {
+            QElapsedTimer nodeWait;
+            nodeWait.start();
+            bool rereadRequested = false;
+            while (!QFile::exists(fatpartition) && nodeWait.elapsed() < 10000)
+            {
+                if (!rereadRequested && nodeWait.elapsed() >= 2000)
+                {
+                    rereadRequested = true;
+                    int fd = open(_filename.constData(), O_RDONLY | O_NONBLOCK | O_CLOEXEC);
+                    if (fd >= 0)
+                    {
+                        if (ioctl(fd, BLKRRPART) != 0)
+                            qDebug() << "BLKRRPART on" << _filename << "failed:" << strerror(errno);
+                        else
+                            qDebug() << "Requested partition table re-read on" << _filename;
+                        close(fd);
+                    }
+                    else
+                    {
+                        qDebug() << "Could not open" << _filename << "for partition re-read:" << strerror(errno);
+                    }
+                }
+                QThread::msleep(100);
+            }
+            qDebug() << "Waited" << nodeWait.elapsed() << "ms for partition node" << fatpartition
+                     << "- exists:" << QFile::exists(fatpartition);
+        }
+
         args << "-t" << "vfat" << fatpartition << folder;
 
         if (QProcess::execute("mount", args) != 0)

--- a/src/downloadextractthread.cpp
+++ b/src/downloadextractthread.cpp
@@ -817,7 +817,7 @@ void DownloadExtractThread::extractMultiFileRun()
             QElapsedTimer nodeWait;
             nodeWait.start();
             bool rereadRequested = false;
-            while (!QFile::exists(fatpartition) && nodeWait.elapsed() < 10000)
+            while (!_cancelled && !QFile::exists(fatpartition) && nodeWait.elapsed() < 10000)
             {
                 if (!rereadRequested && nodeWait.elapsed() >= 2000)
                 {
@@ -840,6 +840,12 @@ void DownloadExtractThread::extractMultiFileRun()
             }
             qDebug() << "Waited" << nodeWait.elapsed() << "ms for partition node" << fatpartition
                      << "- exists:" << QFile::exists(fatpartition);
+
+            // A cancel during that wait must not fall through to mount: the
+            // cancel path has already torn the write down, and _joinExtractThread()
+            // is blocked on this function returning.
+            if (_cancelled)
+                return;
         }
 
         args << "-t" << "vfat" << fatpartition << folder;

--- a/src/downloadextractthread.cpp
+++ b/src/downloadextractthread.cpp
@@ -1091,6 +1091,12 @@ void DownloadExtractThread::extractMultiFileRun()
         // completion signal. PlatformQuirks' legacy Windows result does not
         // reliably distinguish an unrelated volume from a successful eject, so
         // do not turn that result into a new terminal error here.
+        //
+        // On macOS the unmount inside ejectDisk() is what flushes the freshly
+        // extracted files out of the page cache, so it can take tens of
+        // seconds on a slow stick. Without a status update the UI sits on
+        // "Finalising…" the whole time and reads as a hang.
+        emit preparationStatusUpdate(tr("Ejecting storage device… (flushing data, this may take a minute)"));
         PlatformQuirks::ejectDisk(ejectPath);
     }
 

--- a/src/downloadextractthread.cpp
+++ b/src/downloadextractthread.cpp
@@ -428,8 +428,14 @@ void DownloadExtractThread::_onDownloadSuccess()
         return;
     }
 
-    // Extraction thread already called _writeComplete(), so just emit success to signal thread completion
+    // Extraction thread already finished writing; emit success right away and
+    // run the (potentially slow) eject afterwards on this thread, so the done
+    // screen appears immediately with a live eject status.
+    if (_ejectEnabled)
+        emit ejectStarted();
     emit success();
+    if (_ejectEnabled)
+        _performEject();
 }
 
 void DownloadExtractThread::_onDownloadError(const QString &msg)
@@ -1080,32 +1086,26 @@ void DownloadExtractThread::extractMultiFileRun()
     if (_extractFailed || _cancelled)
         return;
 
-    // Give the filesystem a moment to settle after sync before ejecting
-    QThread::msleep(500);
-
-    if (_ejectEnabled)
-    {
-        // Use canonical device path for eject (e.g., /dev/disk on macOS, not rdisk)
-        QString ejectPath = PlatformQuirks::getEjectDevicePath(_filename);
-        // UNRAID: wait for the synchronous eject attempt to finish before the
-        // completion signal. PlatformQuirks' legacy Windows result does not
-        // reliably distinguish an unrelated volume from a successful eject, so
-        // do not turn that result into a new terminal error here.
-        //
-        // On macOS the unmount inside ejectDisk() is what flushes the freshly
-        // extracted files out of the page cache, so it can take tens of
-        // seconds on a slow stick. Without a status update the UI sits on
-        // "Finalising…" the whole time and reads as a hang.
-        emit preparationStatusUpdate(tr("Ejecting storage device… (flushing data, this may take a minute)"));
-        PlatformQuirks::ejectDisk(ejectPath);
-    }
-
-    // UNRAID: downloaded archives have a second extraction thread, and
-    // _onDownloadSuccess() is their sole terminal success owner after waiting for
-    // this method to return. LocalFileExtractThread calls this method inline and
-    // therefore still needs the success signal here.
+    // UNRAID: the eject is announced first and then performed *after*
+    // success(), so the done screen appears immediately and shows a live
+    // "ejecting" status instead of the write screen freezing on
+    // "Finalising…". On macOS the unmount inside ejectDisk() is what flushes
+    // the freshly extracted files out of the page cache, which can take tens
+    // of seconds on a slow stick.
+    //
+    // Downloaded archives have a second extraction thread, and
+    // _onDownloadSuccess() is their sole terminal success owner after waiting
+    // for this method to return; it also owns the eject so the wait cannot
+    // block on it. LocalFileExtractThread calls this method inline and
+    // therefore still needs the success signal and eject here.
     if (!_ethreadStarted)
+    {
+        if (_ejectEnabled)
+            emit ejectStarted();
         emit success();
+        if (_ejectEnabled)
+            _performEject();
+    }
 }
 
 ssize_t DownloadExtractThread::_on_read(struct archive *, const void **buff)

--- a/src/downloadthread.cpp
+++ b/src/downloadthread.cpp
@@ -227,6 +227,12 @@ bool DownloadThread::_openAndPrepareDevice()
 #ifdef Q_OS_WIN
     qDebug() << "device" << _filename;
 
+    // Volumes on the target disk are locked+dismounted and held open for the
+    // duration of prepare (unmount -> clean -> open). Holding the lock keeps
+    // Windows from re-mounting them mid-operation without deleting their
+    // drive-letter bindings, so the letters return after the write. See #1665.
+    DiskpartUtil::LockedVolumes lockedVolumes;
+
     std::regex windriveregex("\\\\\\\\.\\\\PHYSICALDRIVE([0-9]+)", std::regex_constants::icase);
     std::cmatch m;
 
@@ -250,7 +256,7 @@ bool DownloadThread::_openAndPrepareDevice()
 
             // Unmount volumes first (with performance instrumentation)
             emit preparationStatusUpdate(tr("Unmounting volumes..."));
-            auto unmountResult = DiskpartUtil::unmountVolumes(_filename, timingCallback);
+            auto unmountResult = DiskpartUtil::unmountVolumes(_filename, lockedVolumes, timingCallback);
             if (!unmountResult.success)
             {
                 qDebug() << "Warning: Volume unmount had issues:" << unmountResult.errorMessage;
@@ -388,7 +394,21 @@ bool DownloadThread::_openAndPrepareDevice()
     
     // Emit authorization timing event (success case)
     emit eventDriveAuthorization(static_cast<quint32>(authOpenMs), true);
-    
+
+#ifdef Q_OS_WIN
+    // The physical drive is now open and held for the write, which suppresses
+    // partition re-scanning. Release the volume locks we held across prepare:
+    // the disk has been cleaned so there is nothing to re-mount now, and once
+    // the physical-drive handle is closed at the end of the write Windows will
+    // re-scan and reassign drive letters (their Mount Manager bindings were
+    // preserved rather than deleted). See #1665.
+    if (!lockedVolumes.empty())
+    {
+        qDebug() << "Releasing" << lockedVolumes.count() << "held volume lock(s) after opening drive";
+        lockedVolumes.release();
+    }
+#endif
+
     // Apply debug option for direct I/O after opening
     // By default, OpenDevice enables direct I/O for block devices
     // This allows toggling it off via the secret debug menu

--- a/src/downloadthread.cpp
+++ b/src/downloadthread.cpp
@@ -1832,6 +1832,23 @@ void DownloadThread::_writeComplete()
     if (_firstBlock)
     {
         qDebug() << "Writing first block (which we skipped at first)";
+
+        // Force all preceding image data (including the filesystem) to physical
+        // media BEFORE writing the partition table. On write-caching USB card
+        // readers the MBR could otherwise reach the media ahead of the filesystem,
+        // making Windows briefly see a partition with an incomplete filesystem and
+        // pop "You need to format the disk in drive X:". Flushing first guarantees
+        // the partition only becomes visible once its contents are durable. (Same
+        // reasoning as DeviceWrapper::sync() for the customised path.)
+        rpi_imager::FileError preMbrFlush = _file->Flush();
+        if (preMbrFlush != rpi_imager::FileError::kSuccess)
+        {
+            qFreeAligned(_firstBlock);
+            _firstBlock = nullptr;
+            DownloadThread::_onDownloadError(_fileErrorToString(preMbrFlush, tr("flushing image before writing partition table")));
+            return;
+        }
+
         _file->Seek(0);
         rpi_imager::FileError writeResult = _file->WriteSequential(reinterpret_cast<const std::uint8_t*>(_firstBlock), _firstBlockSize);
         rpi_imager::FileError flushResult = (writeResult == rpi_imager::FileError::kSuccess) ? _file->Flush() : writeResult;

--- a/src/downloadthread.cpp
+++ b/src/downloadthread.cpp
@@ -1890,6 +1890,17 @@ void DownloadThread::_writeComplete()
 #endif
 
     emit eventFinalSync(static_cast<quint32>(syncTimer.elapsed()), true);
+
+    /* Customisation is written after _verify() and after the MBR, so this is the
+       first point at which all of it is durable and can be read back. Do it
+       before success() -- the entire point is to not show a green card for a
+       device that dropped the settings. */
+    if (!_verifyCustomisation())
+    {
+        _closeFiles();
+        return;
+    }
+
     _closeFiles();
 
 #ifdef Q_OS_DARWIN
@@ -1905,6 +1916,169 @@ void DownloadThread::_writeComplete()
         QString ejectPath = PlatformQuirks::getEjectDevicePath(_filename);
         PlatformQuirks::ejectDisk(ejectPath);
     }
+}
+
+namespace {
+/* Hash through the platform abstraction (CommonCrypto / GnuTLS / CNG) rather
+   than QCryptographicHash, as the rest of the write path does. */
+QByteArray customisationDigest(const QByteArray &contents)
+{
+    AcceleratedCryptographicHash hash(OSLIST_HASH_ALGORITHM);
+    hash.addData(contents);
+    return hash.result();
+}
+} // namespace
+
+/* Re-read the customisation files from the media and compare them against what
+ * we wrote. The whole-image _verify() pass runs *before* customisation, so
+ * without this the customisation writes are the only part of the card nothing
+ * ever checks -- and a card that quietly drops them produces a successful-looking
+ * write that simply won't accept SSH on first boot.
+ *
+ * Correctness depends on defeating three layers of cache:
+ *   1. DeviceWrapper::_blockcache never evicts on sync(), so reading back
+ *      through the same DeviceWrapper would compare our own buffer against
+ *      itself and always pass. We therefore build a *fresh* wrapper here,
+ *      whose cache starts empty.
+ *   2. The OS page cache: bypassed by direct I/O -- O_DIRECT on Linux,
+ *      F_NOCACHE on macOS, FILE_FLAG_NO_BUFFERING on Windows -- which is
+ *      normally already active for block devices but can have fallen back to
+ *      buffered at open time, so we re-assert it below and record whether it
+ *      actually took.
+ *   3. The card's or USB bridge's own write cache we cannot defeat. A device
+ *      that serves writes back out of DRAM it never committed will still pass
+ *      this check -- as it already passes _verify() for the same reason. This
+ *      catches the visible failures (dropped writes, truncation, bad geometry),
+ *      not a determined counterfeit.
+ *
+ * Note the asymmetry that makes this safe to ship: a cache we failed to defeat
+ * can only ever return the data we wrote, so caching can produce a false *pass*
+ * but never a false *failure*. A reported mismatch is therefore always real
+ * evidence of a problem, which is why it is safe to hard-fail on one.
+ */
+bool DownloadThread::_verifyCustomisation()
+{
+    if (_customisationDigests.isEmpty())
+        return true;
+
+    emit preparationStatusUpdate(tr("Verifying OS customisation..."));
+    QElapsedTimer verifyTimer;
+    verifyTimer.start();
+
+    /* DeviceWrapper reads in 4 KiB blocks, one seek + read syscall each, and with
+     * direct I/O none of it is cached. That is nothing for the customisation
+     * files themselves (kilobytes) but boot.img is tens of megabytes, i.e.
+     * thousands of syscalls added to every secure-boot write. So content-check
+     * large files only when the user already opted into the cost of a read-back
+     * by enabling verification; always content-check the small ones, whose whole
+     * purpose is the customisation that would otherwise fail silently. Size is
+     * checked for everything either way, since it needs no file read. */
+    constexpr qint64 kAlwaysVerifyMaxBytes = 1024 * 1024;
+
+    QStringList missing, mismatched, sizeMismatched, notContentChecked;
+
+    /* Make sure we are reading the media and not a cache. Direct I/O is normally
+       already on for block devices, in which case this is a no-op; it can have
+       fallen back to buffered at open time, though, so ask for it explicitly.
+       (SetDirectIOEnabled returns success immediately when already in the
+       requested state, so the common path costs nothing. On Windows a real
+       change reopens the handle -- acceptable here because everything is already
+       flushed and synced, and a lost handle only downgrades this check to
+       "not checked".) */
+    bool cacheBypassed = _file->IsDirectIOEnabled();
+    if (!cacheBypassed)
+    {
+        cacheBypassed = _file->SetDirectIOEnabled(true) == rpi_imager::FileError::kSuccess
+                        && _file->IsDirectIOEnabled();
+        qDebug() << "DownloadThread: direct I/O was off before customisation read-back; now"
+                 << (cacheBypassed ? "enabled" : "still off");
+    }
+
+    /* Belt and braces: drop any clean pages the OS may still be holding for this
+       range. Effective on Linux (fadvise DONTNEED); a flush-only no-op on
+       Windows. Everything was synced above, so no dirty pages should remain. */
+    _file->PrepareForSequentialRead(0, _bytesWritten.load());
+
+    try
+    {
+        DeviceWrapper dw(_file.get());
+        DeviceWrapperFatPartition *fat = dw.fatPartition(1);
+        if (!fat)
+            throw std::runtime_error("boot partition not found");
+
+        for (auto it = _customisationDigests.constBegin(); it != _customisationDigests.constEnd(); ++it)
+        {
+            if (_cancelled)
+                return true;
+
+            if (!fat->fileExists(it.key()))
+            {
+                missing << it.key();
+                continue;
+            }
+
+            if (it.value().size > kAlwaysVerifyMaxBytes && !_verifyEnabled)
+            {
+                notContentChecked << it.key();
+                continue;
+            }
+
+            const QByteArray actual = fat->readFile(it.key());
+            if (actual.size() != it.value().size)
+                sizeMismatched << it.key();
+            else if (customisationDigest(actual) != it.value().digest)
+                mismatched << it.key();
+        }
+
+        /* Read-only use never marks a block dirty, so the destructor's sync()
+           is a no-op and cannot write anything back. */
+    }
+    catch (std::runtime_error &err)
+    {
+        /* We could not perform the check at all (unreadable or unexpected
+           partition layout). That is not evidence the customisation is bad, so
+           warn and let the write stand rather than failing a good card. */
+        qDebug() << "DownloadThread: could not verify customisation:" << err.what();
+        emit eventCustomisationVerify(static_cast<quint32>(verifyTimer.elapsed()), false,
+                                      QString("%1 files; not checked: %2")
+                                          .arg(_customisationDigests.size()).arg(err.what()));
+        return true;
+    }
+
+    /* Never report full coverage when some files were only size-checked, and
+       always record whether the read actually bypassed the OS cache -- a pass is
+       only as strong as the cache bypass, whereas a failure is trustworthy
+       either way (see the asymmetry noted above). */
+    const QString coverage = QString("%1 files; content-checked: %2; cache-bypassed: %3")
+        .arg(_customisationDigests.size())
+        .arg(_customisationDigests.size() - notContentChecked.size())
+        .arg(cacheBypassed ? "yes" : "no");
+
+    if (missing.isEmpty() && mismatched.isEmpty() && sizeMismatched.isEmpty())
+    {
+        qDebug() << "DownloadThread: customisation verified;" << coverage
+                 << (notContentChecked.isEmpty() ? "" : "size-only: " + notContentChecked.join(","));
+        emit eventCustomisationVerify(static_cast<quint32>(verifyTimer.elapsed()), true, coverage);
+        return true;
+    }
+
+    QStringList affected = missing + sizeMismatched + mismatched;
+    affected.sort();
+    qDebug() << "DownloadThread: customisation verification FAILED - missing:" << missing
+             << "truncated:" << sizeMismatched << "corrupted:" << mismatched;
+    emit eventCustomisationVerify(static_cast<quint32>(verifyTimer.elapsed()), false,
+                                  QString("%1; missing: %2; truncated: %3; corrupted: %4")
+                                      .arg(coverage, missing.join(","),
+                                           sizeMismatched.join(","), mismatched.join(",")));
+
+    emit error(tr("The OS customisation settings were not stored correctly on the device. "
+                  "The following files are missing or damaged: %1.\n\n"
+                  "The device accepted the data but did not keep it, which usually means the "
+                  "SD card or USB adapter is failing or counterfeit. The image itself was "
+                  "written correctly, but the device would not have applied your settings on "
+                  "first boot (so you would not have been able to connect to it). Try a "
+                  "different card or card reader.").arg(affected.join(", ")));
+    return false;
 }
 
 bool DownloadThread::_verify()
@@ -2332,6 +2506,12 @@ void DownloadThread::setDebugIgnoreDeviceLimits(bool enabled)
     qDebug() << "DownloadThread: Ignore device I/O limits" << (enabled ? "enabled" : "disabled");
 }
 
+void DownloadThread::_recordCustomisationWrite(const QString &filename, const QByteArray &contents)
+{
+    _customisationDigests.insert(filename,
+        CustomisationExpectation{ contents.size(), customisationDigest(contents) });
+}
+
 bool DownloadThread::_customizeImage()
 {
     emit preparationStatusUpdate(tr("Customising OS..."));
@@ -2395,6 +2575,7 @@ bool DownloadThread::_customizeImage()
             }
 
             fat->writeFile("config.txt", config);
+            _recordCustomisationWrite("config.txt", config);
         }
 
         // init_format decision is owned by ImageWriter; no auto-detection here
@@ -2405,12 +2586,14 @@ bool DownloadThread::_customizeImage()
             // No need to add them here anymore
             if (_initFormat == "systemd") {
                 fat->writeFile("firstrun.sh", _firstrun);
+                _recordCustomisationWrite("firstrun.sh", _firstrun);
                 _cmdline += " systemd.run=/boot/firstrun.sh systemd.run_success_action=reboot systemd.unit=kernel-command-line.target";
             } else if (_initFormat == "rpi-preseed") {
                 // rpi-preseed applies /boot/firmware/rpi-preseed.toml on first
                 // boot; its units are gated on the file's presence, so no
                 // cmdline entry is required.
                 fat->writeFile("rpi-preseed.toml", _firstrun);
+                _recordCustomisationWrite("rpi-preseed.toml", _firstrun);
             }
         }
 
@@ -2424,6 +2607,7 @@ bool DownloadThread::_customizeImage()
             QByteArray instanceId = "rpi-imager-" + QByteArray::number(QDateTime::currentMSecsSinceEpoch());
             QByteArray metadata = "instance-id: " + instanceId + "\n";
             fat->writeFile("meta-data", metadata);
+            _recordCustomisationWrite("meta-data", metadata);
 
             // Expose datasource type and instance-id on kernel cmdline so that
             // cloud-init's check_instance_id() can validate the cache without
@@ -2437,11 +2621,13 @@ bool DownloadThread::_customizeImage()
             {
                 _cloudinit = "#cloud-config\n"+_cloudinit;
                 fat->writeFile("user-data", _cloudinit);
+                _recordCustomisationWrite("user-data", _cloudinit);
             }
 
             if (!_cloudinitNetwork.isEmpty())
             {
                 fat->writeFile("network-config", _cloudinitNetwork);
+                _recordCustomisationWrite("network-config", _cloudinitNetwork);
             }
         }
 
@@ -2452,6 +2638,7 @@ bool DownloadThread::_customizeImage()
             cmdline += _cmdline;
 
             fat->writeFile("cmdline.txt", cmdline);
+            _recordCustomisationWrite("cmdline.txt", cmdline);
         }
         
         // Sync before secure boot processing (writes partition table/MBR)
@@ -2671,9 +2858,16 @@ bool DownloadThread::_createSecureBootFiles(DeviceWrapperFatPartition *fat)
 
     // NOW write boot.img and boot.sig to the cleaned partition
     emit preparationStatusUpdate(tr("Writing signed boot files..."));
+    /* Everything recorded by _customizeImage() has just been deleted from the
+       partition and folded into boot.img (config.txt and cmdline.txt among
+       them), so those expectations no longer describe the on-disk state.
+       Rebuild the set from what actually survives here. */
+    _customisationDigests.clear();
     try {
         fat->writeFile("boot.img", bootImgData);
         fat->writeFile("boot.sig", bootSigData);
+        _recordCustomisationWrite("boot.img", bootImgData);
+        _recordCustomisationWrite("boot.sig", bootSigData);
         qDebug() << "DownloadThread: secure boot files written successfully";
     }
     catch (std::runtime_error &err) {
@@ -2689,6 +2883,12 @@ bool DownloadThread::_createSecureBootFiles(DeviceWrapperFatPartition *fat)
         emit preparationStatusUpdate(tr("Writing customization files..."));
         qDebug() << "DownloadThread: writing" << customFiles.size() << "customization files back";
         for (auto it = customFiles.constBegin(); it != customFiles.constEnd(); ++it) {
+            /* Record the expectation before attempting the write. If the write
+               below fails we deliberately swallow it (a partial secure-boot
+               partition is still worth finishing), but the recorded digest
+               means _verifyCustomisation() will catch it and fail loudly
+               instead of handing back a card that silently won't customise. */
+            _recordCustomisationWrite(it.key(), it.value());
             try {
                 fat->writeFile(it.key(), it.value());
                 qDebug() << "DownloadThread: wrote customization file:" << it.key();

--- a/src/downloadthread.cpp
+++ b/src/downloadthread.cpp
@@ -2033,6 +2033,15 @@ void DownloadThread::_writeComplete()
         return;
     }
 
+    /* _verifyCustomisation() returns true when it bailed out early because the
+       write was cancelled, so re-check here: without this a cancelled write
+       reaches success() and the done screen shows a green card. */
+    if (_cancelled)
+    {
+        _closeFiles();
+        return;
+    }
+
     _closeFiles();
 
 #ifdef Q_OS_DARWIN
@@ -2225,13 +2234,18 @@ bool DownloadThread::_verifyCustomisation()
                                       .arg(coverage, missing.join(","),
                                            sizeMismatched.join(","), mismatched.join(",")));
 
-    emit error(tr("The OS customisation settings were not stored correctly on the device. "
-                  "The following files are missing or damaged: %1.\n\n"
-                  "The device accepted the data but did not keep it, which usually means the "
-                  "SD card or USB adapter is failing or counterfeit. The image itself was "
-                  "written correctly, but the device would not have applied your settings on "
-                  "first boot (so you would not have been able to connect to it). Try a "
-                  "different card or card reader.").arg(affected.join(", ")));
+    /* Route through _onDownloadError() like every other failure in
+       _writeComplete(): it marks the write cancelled, drops the device handle and
+       refreshes the OS disk view. We have just rewritten the partition table, so
+       on Windows skipping that refresh can leave the drive with no letter. */
+    DownloadThread::_onDownloadError(
+        tr("The OS customisation settings were not stored correctly on the device. "
+           "The following files are missing or damaged: %1.\n\n"
+           "The device accepted the data but did not keep it, which usually means the "
+           "SD card or USB adapter is failing or counterfeit. The image itself was "
+           "written correctly, but the device would not have applied your settings on "
+           "first boot (so you would not have been able to connect to it). Try a "
+           "different card or card reader.").arg(affected.join(", ")));
     return false;
 }
 

--- a/src/downloadthread.cpp
+++ b/src/downloadthread.cpp
@@ -1992,14 +1992,36 @@ void DownloadThread::_writeComplete()
     QThread::sleep(1);
 #endif
 
+    // Announce the eject before success() so the done screen never shows a
+    // stale "safe to remove" while the background eject is still running.
+    if (_ejectEnabled)
+        emit ejectStarted();
+
     emit success();
 
     if (_ejectEnabled)
-    {
-        // Use canonical device path for eject (e.g., /dev/disk on macOS, not rdisk)
-        QString ejectPath = PlatformQuirks::getEjectDevicePath(_filename);
-        PlatformQuirks::ejectDisk(ejectPath);
-    }
+        _performEject();
+}
+
+void DownloadThread::_performEject()
+{
+    // Give the filesystem a moment to settle before ejecting
+    QThread::msleep(500);
+
+    // Use canonical device path for eject (e.g., /dev/disk on macOS, not rdisk)
+    QString ejectPath = PlatformQuirks::getEjectDevicePath(_filename);
+    PlatformQuirks::DiskResult result = PlatformQuirks::ejectDisk(ejectPath);
+
+    bool succeeded = (result == PlatformQuirks::DiskResult::Success);
+#ifdef Q_OS_WIN
+    // The legacy Windows implementation walks every drive letter, so its
+    // result can carry an unrelated volume's failure even when the target
+    // drive ejected fine. Only report a definite miss.
+    succeeded = (result != PlatformQuirks::DiskResult::InvalidDrive);
+#endif
+
+    qDebug() << "Background eject finished for" << ejectPath << "succeeded:" << succeeded;
+    emit ejectFinished(succeeded);
 }
 
 bool DownloadThread::_verify()

--- a/src/downloadthread.h
+++ b/src/downloadthread.h
@@ -15,6 +15,7 @@
 #include <QFile>
 #include <QElapsedTimer>
 #include <QFuture>
+#include <QMap>
 #include <atomic>
 #include <time.h>
 #include <curl/curl.h>
@@ -202,6 +203,7 @@ signals:
     void eventDriveMbrZeroing(quint32 durationMs, bool success, QString metadata);  // MBR zeroing timing
     void eventDirectIOAttempt(bool attempted, bool succeeded, bool currentlyEnabled, int errorCode, QString errorMessage);
     void eventCustomisation(quint32 durationMs, bool success, QString metadata);
+    void eventCustomisationVerify(quint32 durationMs, bool success, QString metadata);  // Customisation read-back check
     void finalSyncStarting();  // Emitted before post-write fdatasync/fsync
     void eventFinalSync(quint32 durationMs, bool success);
     void eventVerify(quint32 durationMs, bool success, QByteArray writeHash, QByteArray verifyHash);
@@ -254,6 +256,10 @@ protected:
     QByteArray _fileGetContentsTrimmed(const QString &filename);
     bool _customizeImage();
     bool _createSecureBootFiles(class DeviceWrapperFatPartition *fat);
+    /* Record what customisation wrote, so _verifyCustomisation() can check the
+       media actually kept it. */
+    void _recordCustomisationWrite(const QString &filename, const QByteArray &contents);
+    bool _verifyCustomisation();
     void _periodicSync();
 
     /*
@@ -274,6 +280,17 @@ protected:
     qint64 _sectorsStart;
     QByteArray _url, _useragent, _buf, _filename, _lastError, _expectedHash, _config, _cmdline, _firstrun, _cloudinit, _cloudinitNetwork, _initFormat;
     ImageOptions::AdvancedOptions _advancedOptions;
+    /* What customisation wrote to the boot partition, keyed by filename. A
+       digest rather than the contents, so recording boot.img costs 32 bytes
+       rather than a second copy of a multi-MB buffer. The size is kept
+       separately because it can be checked without reading the file back --
+       truncation is both the commonest signature of a dropped write and the
+       cheapest to detect. */
+    struct CustomisationExpectation {
+        qint64 size;
+        QByteArray digest;  // OSLIST_HASH_ALGORITHM, via AcceleratedCryptographicHash
+    };
+    QMap<QString, CustomisationExpectation> _customisationDigests;
     char *_firstBlock;
     size_t _firstBlockSize;
     static QByteArray _proxy;

--- a/src/downloadthread.h
+++ b/src/downloadthread.h
@@ -199,6 +199,12 @@ signals:
     void cacheFileHashUpdated(QByteArray cacheFileHash, QByteArray imageHash);
     void finalizing();
     void preparationStatusUpdate(QString msg);
+    // Background eject progress after a successful write. ejectStarted() is
+    // emitted before success() so the UI already shows "ejecting" when the
+    // done screen appears; ejectFinished() follows when the drive is safe to
+    // remove (or the eject gave up).
+    void ejectStarted();
+    void ejectFinished(bool succeeded);
     
     // Performance event signals (connected by ImageWriter to PerformanceStats)
     void eventDriveUnmount(quint32 durationMs, bool success);
@@ -251,6 +257,7 @@ protected:
 
     void _hashData(const char *buf, size_t len);
     void _writeComplete();
+    void _performEject();
     virtual bool _verify();
     virtual void _onVerifyProgress() {}  // Called during verify loop for progress updates
     int _authopen(const QByteArray &filename);

--- a/src/drivelistmodelpollthread.cpp
+++ b/src/drivelistmodelpollthread.cpp
@@ -157,6 +157,25 @@ void DriveListModelPollThread::run()
                         cache.fastbootId = std::to_string(dev.busNumber) + ":" + std::to_string(dev.deviceAddress);
                         cache.portPath = dev.portPath;
 
+                        // Positively identify a genuine rpi-fastbootd gadget
+                        // before exposing it as a flashable target. The gadget
+                        // borrows Google's 18d1:4e40 VID/PID, so a non-Pi
+                        // device (e.g. an Android phone in a colliding fastboot
+                        // mode) could enumerate identically. isRpiFastboot()
+                        // checks the authoritative USB interface descriptor
+                        // ("fastbootd-provisioner") and falls back to the
+                        // RPi-specific block-devices getvar. If neither
+                        // confirms a Pi, cache a storage-less entry so the
+                        // device is neither listed as a target nor re-probed on
+                        // every tick, and skip it.
+                        if (!fb.isRpiFastboot(*transport)) {
+                            qDebug() << "Fastboot: ignoring non-RPi device at"
+                                     << QString::fromStdString(ppKey)
+                                     << "(did not identify as rpi-fastbootd)";
+                            _fastbootCache[ppKey] = std::move(cache);
+                            continue;
+                        }
+
                         // Query product name
                         auto product = fb.getVar(*transport, "product");
                         cache.productName = product.value_or("Compute Module");

--- a/src/drivelistmodelpollthread.cpp
+++ b/src/drivelistmodelpollthread.cpp
@@ -161,18 +161,30 @@ void DriveListModelPollThread::run()
                         // before exposing it as a flashable target. The gadget
                         // borrows Google's 18d1:4e40 VID/PID, so a non-Pi
                         // device (e.g. an Android phone in a colliding fastboot
-                        // mode) could enumerate identically. isRpiFastboot()
+                        // mode) could enumerate identically. identifyRpiFastboot()
                         // checks the authoritative USB interface descriptor
                         // ("fastbootd-provisioner") and falls back to the
-                        // RPi-specific block-devices getvar. If neither
-                        // confirms a Pi, cache a storage-less entry so the
-                        // device is neither listed as a target nor re-probed on
-                        // every tick, and skip it.
-                        if (!fb.isRpiFastboot(*transport)) {
+                        // RPi-specific block-devices getvar. Only a device that
+                        // actually answered and denied it is cached as a
+                        // storage-less entry, so it is neither listed as a
+                        // target nor re-probed on every tick; a probe that got
+                        // no answer is retried instead of being banked.
+                        const auto identity = fb.identifyRpiFastboot(*transport);
+                        if (identity == fastboot::RpiIdentity::ConfirmedNotPi) {
                             qDebug() << "Fastboot: ignoring non-RPi device at"
                                      << QString::fromStdString(ppKey)
                                      << "(did not identify as rpi-fastbootd)";
                             _fastbootCache[ppKey] = std::move(cache);
+                            continue;
+                        }
+                        if (identity == fastboot::RpiIdentity::Inconclusive) {
+                            // The probe got no answer — which is also what a Pi
+                            // still starting its gadget looks like. Caching this
+                            // would strand a genuine device until it is
+                            // unplugged, so skip the tick and re-probe next one.
+                            qDebug() << "Fastboot: identity probe inconclusive at"
+                                     << QString::fromStdString(ppKey)
+                                     << "- will retry on the next scan";
                             continue;
                         }
 

--- a/src/fastboot/fastboot_protocol.cpp
+++ b/src/fastboot/fastboot_protocol.cpp
@@ -428,6 +428,26 @@ std::optional<std::string> FastbootProtocol::getVar(rpiboot::IUsbTransport& tran
     return std::nullopt;
 }
 
+// ── Device identification ──────────────────────────────────────────────
+
+bool FastbootProtocol::isRpiFastboot(rpiboot::IUsbTransport& transport)
+{
+    // Prefer the authoritative signal: the USB interface string descriptor
+    // the RPi gadget advertises ("fastbootd-provisioner").  It is available
+    // at open time, before any fastboot command, and stock Android
+    // fastboot/fastbootd advertises "fastbootd" / "Android Fastboot" instead.
+    if (transport.interfaceString() == rpiboot::FASTBOOT_INTERFACE_DESCRIPTOR)
+        return true;
+
+    // Fall back to a protocol-level probe: rpi-fastbootd implements the
+    // RPi-specific "block-devices" getvar to enumerate flashable storage,
+    // which stock Android fastboot does not (→ getVar yields nullopt).  This
+    // covers transports that cannot read the descriptor (e.g. non-USB) and
+    // gadgets built with a customised interface string, while still rejecting
+    // a non-Pi device that merely matches the borrowed 18d1:4e40 VID/PID.
+    return getVar(transport, "block-devices").has_value();
+}
+
 // ── Combined flash ─────────────────────────────────────────────────────
 
 bool FastbootProtocol::flashImage(rpiboot::IUsbTransport& transport,

--- a/src/fastboot/fastboot_protocol.cpp
+++ b/src/fastboot/fastboot_protocol.cpp
@@ -182,6 +182,9 @@ bool FastbootProtocol::stage(rpiboot::IUsbTransport& transport,
                               rpiboot::ProgressCallback progress,
                               std::atomic<bool>& cancelled)
 {
+    // Deliberately "download", not "stage" — see stage() in the header.
+    // rpi-fastbootd maps both verbs to the same DownloadHandler and only
+    // accepts "download" on restricted TCP data-plane connections.
     return sendData(transport, "download", data, progress, cancelled);
 }
 

--- a/src/fastboot/fastboot_protocol.cpp
+++ b/src/fastboot/fastboot_protocol.cpp
@@ -26,7 +26,9 @@ Response FastbootProtocol::readResponse(rpiboot::IUsbTransport& transport, int t
 
     int bytesRead = transport.bulkRead(EP_IN, span, timeoutMs);
     if (bytesRead < 4) {
-        return {Response::Fail, "Short or failed read from device", 0};
+        // No usable answer came back. This is not the device saying "no" — it
+        // is the device saying nothing — so report it distinctly.
+        return {Response::TransportError, "Short or failed read from device", 0};
     }
 
     std::string raw(reinterpret_cast<const char*>(buf), static_cast<size_t>(bytesRead));
@@ -80,7 +82,7 @@ FastbootProtocol::CaptureResult FastbootProtocol::sendCommandCapture(
 
     int written = transport.bulkWrite(EP_OUT, data, timeoutMs);
     if (written < 0) {
-        result.terminal = {Response::Fail, "Failed to send command", 0};
+        result.terminal = {Response::TransportError, "Failed to send command", 0};
         return result;
     }
 
@@ -433,22 +435,34 @@ std::optional<std::string> FastbootProtocol::getVar(rpiboot::IUsbTransport& tran
 
 // ── Device identification ──────────────────────────────────────────────
 
-bool FastbootProtocol::isRpiFastboot(rpiboot::IUsbTransport& transport)
+RpiIdentity FastbootProtocol::identifyRpiFastboot(rpiboot::IUsbTransport& transport)
 {
     // Prefer the authoritative signal: the USB interface string descriptor
     // the RPi gadget advertises ("fastbootd-provisioner").  It is available
     // at open time, before any fastboot command, and stock Android
     // fastboot/fastbootd advertises "fastbootd" / "Android Fastboot" instead.
     if (transport.interfaceString() == rpiboot::FASTBOOT_INTERFACE_DESCRIPTOR)
-        return true;
+        return RpiIdentity::ConfirmedPi;
 
     // Fall back to a protocol-level probe: rpi-fastbootd implements the
     // RPi-specific "block-devices" getvar to enumerate flashable storage,
-    // which stock Android fastboot does not (→ getVar yields nullopt).  This
-    // covers transports that cannot read the descriptor (e.g. non-USB) and
-    // gadgets built with a customised interface string, while still rejecting
-    // a non-Pi device that merely matches the borrowed 18d1:4e40 VID/PID.
-    return getVar(transport, "block-devices").has_value();
+    // which stock Android fastboot does not (→ FAIL).  This covers transports
+    // that cannot read the descriptor (e.g. non-USB) and gadgets built with a
+    // customised interface string, while still rejecting a non-Pi device that
+    // merely matches the borrowed 18d1:4e40 VID/PID.
+    auto resp = sendCommand(transport, "getvar:block-devices", 3000);
+    switch (resp.type) {
+    case Response::Okay:
+        // Implementing the getvar at all is the positive signal; an empty list
+        // just means a Pi with no attached storage.
+        return RpiIdentity::ConfirmedPi;
+    case Response::TransportError:
+        // Nothing answered. A Pi whose gadget is still coming up looks exactly
+        // like this, so leave the question open rather than banking a "no".
+        return RpiIdentity::Inconclusive;
+    default:
+        return RpiIdentity::ConfirmedNotPi;
+    }
 }
 
 // ── Combined flash ─────────────────────────────────────────────────────

--- a/src/fastboot/fastboot_protocol.cpp
+++ b/src/fastboot/fastboot_protocol.cpp
@@ -80,9 +80,13 @@ FastbootProtocol::CaptureResult FastbootProtocol::sendCommandCapture(
     auto data = std::span<const uint8_t>(
         reinterpret_cast<const uint8_t*>(command.data()), command.size());
 
+    // A command is one small ASCII write with no continuation, so a short write
+    // is not something to resume — it means the device received a truncated
+    // command, and any response we then read is answering something we did not
+    // ask. Treat it exactly like a failed write.
     int written = transport.bulkWrite(EP_OUT, data, timeoutMs);
-    if (written < 0) {
-        result.terminal = {Response::TransportError, "Failed to send command", 0};
+    if (written < 0 || static_cast<size_t>(written) != data.size()) {
+        result.terminal = {Response::TransportError, "Failed to send complete command", 0};
         return result;
     }
 
@@ -125,9 +129,12 @@ bool FastbootProtocol::sendData(rpiboot::IUsbTransport& transport,
 
     auto cmdSpan = std::span<const uint8_t>(
         reinterpret_cast<const uint8_t*>(cmd), static_cast<size_t>(cmdLen));
+    // Short write means a truncated command header — see sendCommandCapture().
+    // Here it would be read back as a bad size, so fail rather than stream a
+    // payload the device is not expecting.
     int written = transport.bulkWrite(EP_OUT, cmdSpan, 3000);
-    if (written < 0) {
-        _lastError = std::string("Failed to send ") + std::string(commandPrefix) + " command";
+    if (written < 0 || static_cast<size_t>(written) != cmdSpan.size()) {
+        _lastError = std::string("Failed to send complete ") + std::string(commandPrefix) + " command";
         return false;
     }
 
@@ -206,9 +213,10 @@ std::vector<uint8_t> FastbootProtocol::upload(rpiboot::IUsbTransport& transport,
     const char* cmd = "upload";
     auto cmdSpan = std::span<const uint8_t>(
         reinterpret_cast<const uint8_t*>(cmd), std::strlen(cmd));
+    // Short write means a truncated command — see sendCommandCapture().
     int written = transport.bulkWrite(EP_OUT, cmdSpan, 3000);
-    if (written < 0) {
-        _lastError = "Failed to send upload command";
+    if (written < 0 || static_cast<size_t>(written) != cmdSpan.size()) {
+        _lastError = "Failed to send complete upload command";
         return {};
     }
 

--- a/src/fastboot/fastboot_protocol.h
+++ b/src/fastboot/fastboot_protocol.h
@@ -86,6 +86,21 @@ public:
     std::optional<std::string> getVar(rpiboot::IUsbTransport& transport,
                                        std::string_view name);
 
+    // Positively identify a genuine rpi-fastbootd gadget.
+    //
+    // The RPi fastboot gadget borrows Google's USB VID/PID (18d1:4e40), so
+    // matching that VID/PID does NOT prove the device is a Raspberry Pi — a
+    // non-Pi device (e.g. an Android phone in a colliding fastboot mode)
+    // could enumerate identically.  Identifies via, in order:
+    //   1. the transport's USB interface descriptor — the RPi gadget
+    //      advertises "fastbootd-provisioner" (authoritative, no I/O beyond
+    //      the descriptor already read at open time); then
+    //   2. a fallback probe of the RPi-specific "block-devices" getvar, which
+    //      stock Android fastboot/fastbootd does not implement (FAILs), for
+    //      transports that cannot read the descriptor or customised gadgets.
+    // Returns true only when one of these confirms a Pi; false otherwise.
+    bool isRpiFastboot(rpiboot::IUsbTransport& transport);
+
     // Combined download + flash in one call.
     bool flashImage(rpiboot::IUsbTransport& transport,
                     std::string_view partition,

--- a/src/fastboot/fastboot_protocol.h
+++ b/src/fastboot/fastboot_protocol.h
@@ -61,8 +61,13 @@ public:
                   rpiboot::ProgressCallback progress,
                   std::atomic<bool>& cancelled);
 
-    // Stage data on the device (for use with oem commands).
-    // Identical wire format to download() but uses "stage:" prefix.
+    // Stage data on the device for a subsequent oem command to consume.
+    // Wire-identical to download() — it deliberately uses the "download:"
+    // verb, NOT "stage:".  On rpi-fastbootd both dispatch to the same
+    // DownloadHandler (the device keeps a "stage" alias only for backward
+    // compat with older imagers), and "download" is the only staging verb
+    // accepted on a restricted TCP data-plane connection.  Kept as a distinct
+    // name from download() to document staging intent at call sites.
     bool stage(rpiboot::IUsbTransport& transport,
                std::span<const uint8_t> data,
                rpiboot::ProgressCallback progress,

--- a/src/fastboot/fastboot_protocol.h
+++ b/src/fastboot/fastboot_protocol.h
@@ -25,10 +25,22 @@
 namespace fastboot {
 
 struct Response {
-    enum Type { Okay, Fail, Data, Info, Text };
+    // TransportError means we never heard from the device at all (the bulk
+    // write or read failed), as opposed to Fail, which is the device answering
+    // and refusing. Callers that only ask "did this succeed?" can keep testing
+    // against Okay; callers that must not confuse "no" with "no answer" —
+    // device identification, above all — have to tell the two apart.
+    enum Type { Okay, Fail, Data, Info, Text, TransportError };
     Type type = Fail;
     std::string message;
     uint32_t dataSize = 0;  // Only valid for Data type
+};
+
+// Outcome of identifying a device as a genuine rpi-fastbootd gadget.
+enum class RpiIdentity {
+    ConfirmedPi,     // the descriptor or the block-devices getvar confirms it
+    ConfirmedNotPi,  // the device answered the probe and denied it
+    Inconclusive,    // the probe never got an answer; identity still unknown
 };
 
 class FastbootProtocol {
@@ -103,8 +115,13 @@ public:
     //   2. a fallback probe of the RPi-specific "block-devices" getvar, which
     //      stock Android fastboot/fastbootd does not implement (FAILs), for
     //      transports that cannot read the descriptor or customised gadgets.
-    // Returns true only when one of these confirms a Pi; false otherwise.
-    bool isRpiFastboot(rpiboot::IUsbTransport& transport);
+    //
+    // A transport failure is reported as Inconclusive rather than as a denial:
+    // a genuine Pi that is still bringing its gadget up answers nothing for a
+    // moment, and treating that as ConfirmedNotPi would strand it. Callers
+    // deciding whether to *write* must require ConfirmedPi; callers deciding
+    // whether to *remember* a rejection must accept only ConfirmedNotPi.
+    RpiIdentity identifyRpiFastboot(rpiboot::IUsbTransport& transport);
 
     // Combined download + flash in one call.
     bool flashImage(rpiboot::IUsbTransport& transport,

--- a/src/fastbootflashthread.cpp
+++ b/src/fastbootflashthread.cpp
@@ -646,6 +646,74 @@ void FastbootFlashThread::run()
     }
 }
 
+bool FastbootFlashThread::isEraseOperation() const
+{
+    return _imageUrl.toString() == QLatin1String("internal://format");
+}
+
+bool FastbootFlashThread::performErase(fastboot::FastbootProtocol& fb,
+                                        rpiboot::IUsbTransport& transport)
+{
+    // The block device is the whole disk (e.g. "mmcblk0"); the flash path
+    // targets it directly and mounts "<dev>p1", so no partition suffix here.
+    const std::string dev = _blockDevice.toStdString();
+
+    // 1. Bare wipe of the whole device. The daemon's erase handler calls
+    //    wipe_block_device(), which issues BLKDISCARD (near-instant on eMMC
+    //    that supports it) or falls back to zeroing the device — which can
+    //    take minutes on a large eMMC — so give it a generous timeout.
+    emit preparationStatusUpdate(tr("Erasing storage device..."));
+    qDebug() << "FastbootFlashThread: erase:" << QString::fromStdString(dev);
+    auto resp = fb.sendCommand(transport, "erase:" + dev, 600000);
+    if (_cancelled.load()) {
+        emit error(tr("Cancelled"));
+        return false;
+    }
+    if (resp.type != fastboot::Response::Okay) {
+        emit error(tr("Failed to erase device: %1")
+                   .arg(QString::fromStdString(resp.message)));
+        return false;
+    }
+
+    // 2. Write a fresh MBR (msdos) partition table.
+    emit preparationStatusUpdate(tr("Writing partition table..."));
+    qDebug() << "FastbootFlashThread: oem partinit" << QString::fromStdString(dev) << "dos";
+    resp = fb.sendCommand(transport, "oem partinit " + dev + " dos", 60000);
+    if (resp.type != fastboot::Response::Okay) {
+        emit error(tr("Failed to write partition table: %1")
+                   .arg(QString::fromStdString(resp.message)));
+        return false;
+    }
+
+    // 3. Append a single FAT32-LBA partition spanning the whole device.
+    //    'c' is parsed as hex 0x0c (FAT32 LBA — matching DiskFormatter's
+    //    partition type) by the daemon's partapp handler; omitting the size
+    //    consumes all remaining space, and the daemon aligns the start to
+    //    4 MiB. This only writes the partition *entry* — rpi-fastbootd has
+    //    no mkfs, so the partition is typed FAT32 but has no filesystem.
+    emit preparationStatusUpdate(tr("Creating FAT32 partition..."));
+    qDebug() << "FastbootFlashThread: oem partapp" << QString::fromStdString(dev) << "c";
+    resp = fb.sendCommand(transport, "oem partapp " + dev + " c", 60000);
+    if (resp.type != fastboot::Response::Okay) {
+        emit error(tr("Failed to create partition: %1")
+                   .arg(QString::fromStdString(resp.message)));
+        return false;
+    }
+
+    // 4. Reboot out of fastboot mode.
+    emit finalizing();
+    resp = fb.sendCommand(transport, "reboot", 10000);
+    if (resp.type != fastboot::Response::Okay) {
+        qDebug() << "FastbootFlashThread: reboot command returned:"
+                 << QString::fromStdString(resp.message);
+        // Non-fatal — the erase + partitioning already succeeded.
+    }
+
+    qDebug() << "FastbootFlashThread: erase complete for" << QString::fromStdString(dev);
+    emit success();
+    return true;
+}
+
 void FastbootFlashThread::runImpl()
 {
     emit preparationStatusUpdate(tr("Connecting to fastboot device..."));
@@ -675,8 +743,19 @@ void FastbootFlashThread::runImpl()
         return;
     }
 
-    // 2. Query max-download-size
     fastboot::FastbootProtocol fb;
+
+    // Special case: the "Erase" OS-list entry carries no image. Wipe the
+    // device and write a fresh partition table instead of running the
+    // download/decompress/flash pipeline.
+    if (isEraseOperation()) {
+        emit eventFastbootDeviceOpen(static_cast<quint32>(deviceOpenTimer.elapsed()), true,
+                                     QStringLiteral("erase"));
+        performErase(fb, *transport);
+        return;
+    }
+
+    // 2. Query max-download-size
     auto maxDlSizeStr = fb.getVar(*transport, "max-download-size");
     uint32_t maxDownloadSize = DEFAULT_MAX_DOWNLOAD_SIZE;
     if (maxDlSizeStr) {

--- a/src/fastbootflashthread.cpp
+++ b/src/fastbootflashthread.cpp
@@ -745,6 +745,20 @@ void FastbootFlashThread::runImpl()
 
     fastboot::FastbootProtocol fb;
 
+    // Safety gate: refuse to touch anything that is not a genuine
+    // rpi-fastbootd gadget. The device matched only on the 18d1:4e40 VID/PID
+    // the gadget borrows from Google, so verify its identity before issuing
+    // any destructive command (erase / partition / flash). isRpiFastboot()
+    // checks the authoritative USB interface descriptor ("fastbootd-provisioner")
+    // and falls back to the RPi-specific block-devices getvar. This ensures a
+    // non-Pi device in a colliding fastboot mode can never be written to,
+    // even if it somehow reached this point.
+    if (!fb.isRpiFastboot(*transport)) {
+        emit error(tr("Refusing to flash %1: the device did not identify as a "
+                      "Raspberry Pi fastboot device.").arg(_fastbootId));
+        return;
+    }
+
     // Special case: the "Erase" OS-list entry carries no image. Wipe the
     // device and write a fresh partition table instead of running the
     // download/decompress/flash pipeline.

--- a/src/fastbootflashthread.cpp
+++ b/src/fastbootflashthread.cpp
@@ -658,6 +658,19 @@ bool FastbootFlashThread::performErase(fastboot::FastbootProtocol& fb,
     // targets it directly and mounts "<dev>p1", so no partition suffix here.
     const std::string dev = _blockDevice.toStdString();
 
+    // Every step below is destructive, so cancellation is checked before and
+    // after each one: a cancel landing between two commands must not let the
+    // next one run, and must never reach emit success().
+    auto stopIfCancelled = [this]() {
+        if (!_cancelled.load())
+            return false;
+        emit error(tr("Cancelled"));
+        return true;
+    };
+
+    if (stopIfCancelled())
+        return false;
+
     // 1. Bare wipe of the whole device. The daemon's erase handler calls
     //    wipe_block_device(), which issues BLKDISCARD (near-instant on eMMC
     //    that supports it) or falls back to zeroing the device — which can
@@ -665,8 +678,7 @@ bool FastbootFlashThread::performErase(fastboot::FastbootProtocol& fb,
     emit preparationStatusUpdate(tr("Erasing storage device..."));
     qDebug() << "FastbootFlashThread: erase:" << QString::fromStdString(dev);
     auto resp = fb.sendCommand(transport, "erase:" + dev, 600000);
-    if (_cancelled.load()) {
-        emit error(tr("Cancelled"));
+    if (stopIfCancelled()) {
         return false;
     }
     if (resp.type != fastboot::Response::Okay) {
@@ -679,6 +691,9 @@ bool FastbootFlashThread::performErase(fastboot::FastbootProtocol& fb,
     emit preparationStatusUpdate(tr("Writing partition table..."));
     qDebug() << "FastbootFlashThread: oem partinit" << QString::fromStdString(dev) << "dos";
     resp = fb.sendCommand(transport, "oem partinit " + dev + " dos", 60000);
+    if (stopIfCancelled()) {
+        return false;
+    }
     if (resp.type != fastboot::Response::Okay) {
         emit error(tr("Failed to write partition table: %1")
                    .arg(QString::fromStdString(resp.message)));
@@ -694,6 +709,9 @@ bool FastbootFlashThread::performErase(fastboot::FastbootProtocol& fb,
     emit preparationStatusUpdate(tr("Creating FAT32 partition..."));
     qDebug() << "FastbootFlashThread: oem partapp" << QString::fromStdString(dev) << "c";
     resp = fb.sendCommand(transport, "oem partapp " + dev + " c", 60000);
+    if (stopIfCancelled()) {
+        return false;
+    }
     if (resp.type != fastboot::Response::Okay) {
         emit error(tr("Failed to create partition: %1")
                    .arg(QString::fromStdString(resp.message)));
@@ -748,12 +766,16 @@ void FastbootFlashThread::runImpl()
     // Safety gate: refuse to touch anything that is not a genuine
     // rpi-fastbootd gadget. The device matched only on the 18d1:4e40 VID/PID
     // the gadget borrows from Google, so verify its identity before issuing
-    // any destructive command (erase / partition / flash). isRpiFastboot()
+    // any destructive command (erase / partition / flash). identifyRpiFastboot()
     // checks the authoritative USB interface descriptor ("fastbootd-provisioner")
     // and falls back to the RPi-specific block-devices getvar. This ensures a
     // non-Pi device in a colliding fastboot mode can never be written to,
     // even if it somehow reached this point.
-    if (!fb.isRpiFastboot(*transport)) {
+    //
+    // Only a positive confirmation is good enough here: an inconclusive probe
+    // means we do not know what this device is, and "unknown" must never be
+    // enough to start erasing it.
+    if (fb.identifyRpiFastboot(*transport) != fastboot::RpiIdentity::ConfirmedPi) {
         emit error(tr("Refusing to flash %1: the device did not identify as a "
                       "Raspberry Pi fastboot device.").arg(_fastbootId));
         return;

--- a/src/fastbootflashthread.h
+++ b/src/fastbootflashthread.h
@@ -79,6 +79,19 @@ private:
     bool applyCustomisation(class fastboot::FastbootProtocol& fb,
                              class rpiboot::IUsbTransport& transport);
 
+    // True when this is the special "Erase" OS-list entry
+    // (_imageUrl == "internal://format") rather than a real image flash.
+    bool isEraseOperation() const;
+
+    // Handle the "Erase" case for a fastboot device: bare-wipe the whole
+    // block device, then lay down a fresh MBR with a single FAT32-typed
+    // partition spanning the device, and reboot.  NB: rpi-fastbootd has no
+    // mkfs command, so the partition is *typed* FAT32 but left without a
+    // filesystem --- unlike the SD-card Erase path (DriveFormatThread),
+    // which writes a mountable FAT32.  Emits success()/error() itself.
+    bool performErase(class fastboot::FastbootProtocol& fb,
+                      class rpiboot::IUsbTransport& transport);
+
     // Best-effort: after the OS image has been flashed, set the
     // EEPROM's BOOT_ORDER so the chosen storage device boots first on
     // the next power cycle. Reads the device's existing EEPROM, edits

--- a/src/imagewriter.cpp
+++ b/src/imagewriter.cpp
@@ -4317,9 +4317,14 @@ QString ImageWriter::customRepoHost()
 
 bool ImageWriter::isValidRepoUrl(const QString &url) const
 {
-    // Validate: must be http/https URL ending with .json or manifest extension
+    // Validate: must be an http/https URL whose path ends with .json or the
+    // manifest extension. An optional query string and/or fragment is allowed
+    // after the extension so that pre-signed URLs (e.g. cloud blob storage with
+    // a SAS token: ".../manifest.json?sv=...&sig=...") are accepted. The path
+    // portion excludes '?' and '#' so the extension must appear before any
+    // query/fragment rather than merely somewhere in the URL.
     static const QRegularExpression repoUrlRe(
-        QStringLiteral("^https?://[^ \\t\\r\\n]+\\.(json|" MANIFEST_EXTENSION ")$"), 
+        QStringLiteral("^https?://[^ \\t\\r\\n?#]+\\.(json|" MANIFEST_EXTENSION ")([?#][^ \\t\\r\\n]*)?$"),
         QRegularExpression::CaseInsensitiveOption);
     return repoUrlRe.match(url).hasMatch();
 }

--- a/src/imagewriter.cpp
+++ b/src/imagewriter.cpp
@@ -1553,6 +1553,10 @@ void ImageWriter::startWrite()
             this, [this](quint32 durationMs, bool success, QString metadata){
                 _performanceStats->recordEvent(PerformanceStats::EventType::Customisation, durationMs, success, metadata);
             });
+    connect(_thread, &DownloadThread::eventCustomisationVerify,
+            this, [this](quint32 durationMs, bool success, QString metadata){
+                _performanceStats->recordEvent(PerformanceStats::EventType::CustomisationVerify, durationMs, success, metadata);
+            });
     connect(_thread, &DownloadThread::eventFinalSync,
             this, [this](quint32 durationMs, bool success){
                 _performanceStats->recordEvent(PerformanceStats::EventType::FinalSync, durationMs, success);
@@ -4647,6 +4651,10 @@ void ImageWriter::_continueStartWriteAfterCacheVerification(bool cacheIsValid)
     connect(_thread, &DownloadThread::eventCustomisation,
             this, [this](quint32 durationMs, bool success, QString metadata){
                 _performanceStats->recordEvent(PerformanceStats::EventType::Customisation, durationMs, success, metadata);
+            });
+    connect(_thread, &DownloadThread::eventCustomisationVerify,
+            this, [this](quint32 durationMs, bool success, QString metadata){
+                _performanceStats->recordEvent(PerformanceStats::EventType::CustomisationVerify, durationMs, success, metadata);
             });
     connect(_thread, &DownloadThread::eventFinalSync,
             this, [this](quint32 durationMs, bool success){

--- a/src/imagewriter.cpp
+++ b/src/imagewriter.cpp
@@ -2938,58 +2938,28 @@ void ImageWriter::_parseZstdFile()
         return;
     }
 
-    // Two-stage: read just enough bytes to query the actual frame header size,
-    // then read the remainder. ZSTD_FRAMEHEADERSIZE_PREFIX is the minimum input
-    // size required to call ZSTD_frameHeaderSize().
-    constexpr qint64 prefixSize = ZSTD_FRAMEHEADERSIZE_PREFIX(ZSTD_f_zstd1);
-    QByteArray header = f.read(prefixSize);
-    if (header.size() < prefixSize)
-    {
-        qDebug() << "Unable to read .zst frame prefix";
-        f.close();
-        return;
-    }
-
-    size_t hdrSize = ZSTD_frameHeaderSize(header.constData(), header.size());
-    if (ZSTD_isError(hdrSize))
-    {
-        qDebug() << "Invalid .zst frame header:" << ZSTD_getErrorName(hdrSize);
-        f.close();
-        return;
-    }
-
-    if (static_cast<qint64>(hdrSize) > prefixSize)
-    {
-        header.append(f.read(static_cast<qint64>(hdrSize) - prefixSize));
-    }
+    // ZSTD_findDecompressedSize() iterates through all concatenated frames
+    // to compute the total decompressed size. It requires the full compressed
+    // data in memory, but this is acceptable for custom file size estimates.
+    QByteArray data = f.readAll();
     f.close();
 
-    if (static_cast<size_t>(header.size()) < hdrSize)
+    if (data.isEmpty())
     {
-        qDebug() << "Truncated .zst frame header";
+        qDebug() << "Empty .zst file";
         return;
     }
 
-    unsigned long long fcs = ZSTD_getFrameContentSize(header.constData(),
-                                                     static_cast<size_t>(header.size()));
+    unsigned long long fcs = ZSTD_findDecompressedSize(data.constData(), data.size());
 
-    if (fcs == ZSTD_CONTENTSIZE_ERROR)
+    if (fcs == 0)
     {
-        qDebug() << "Unable to parse .zst frame header";
-        return;
-    }
-    if (fcs == ZSTD_CONTENTSIZE_UNKNOWN)
-    {
-        // First-frame Frame_Content_Size is absent; can't determine without
-        // decompressing. Leave _extrLen=0 and progress will fall back to the
-        // download size (the existing behaviour, with progress > 100%).
-        qDebug() << "Parsed .zst file. Uncompressed size: unknown (FCS not present)";
+        // Could be ZSTD_CONTENTSIZE_ERROR or ZSTD_CONTENTSIZE_UNKNOWN,
+        // or a valid zero-size file. Fall back to unknown.
+        qDebug() << "Unable to determine decompressed size of .zst file";
         return;
     }
 
-    // Note: this is the size of the FIRST zstd frame only. Multi-frame .zst
-    // files would understate the total decompressed size. Single-frame is
-    // the standard case for OS images.
     _extrLen = fcs;
     qDebug() << "Parsed .zst file. Uncompressed size:" << _extrLen;
 }

--- a/src/imagewriter.cpp
+++ b/src/imagewriter.cpp
@@ -3113,10 +3113,26 @@ void ImageWriter::_parseZstdFile()
 
     unsigned long long fcs = ZSTD_findDecompressedSize(data.constData(), data.size());
 
+    // The failure sentinels are (0ULL - 2) and (0ULL - 1), not 0, so they have to
+    // be tested by name: comparing against 0 alone lets ZSTD_CONTENTSIZE_UNKNOWN
+    // through as _extrLen = ULLONG_MAX, and startWrite() then rejects a perfectly
+    // good local image with "Storage capacity is not large enough".
+    if (fcs == ZSTD_CONTENTSIZE_ERROR)
+    {
+        qDebug() << "Unable to parse .zst file (invalid or truncated frames)";
+        return;
+    }
+
+    if (fcs == ZSTD_CONTENTSIZE_UNKNOWN)
+    {
+        // Size not recorded in the frame headers (streaming-compressed input).
+        // Leave _extrLen unknown and let progress fall back to the download size.
+        qDebug() << "Parsed .zst file. Uncompressed size: unknown (FCS not present)";
+        return;
+    }
+
     if (fcs == 0)
     {
-        // Could be ZSTD_CONTENTSIZE_ERROR or ZSTD_CONTENTSIZE_UNKNOWN,
-        // or a valid zero-size file. Fall back to unknown.
         qDebug() << "Unable to determine decompressed size of .zst file";
         return;
     }

--- a/src/imagewriter.cpp
+++ b/src/imagewriter.cpp
@@ -512,8 +512,14 @@ ImageWriter::~ImageWriter()
     if (_manualEjectThread) {
         qDebug() << "Waiting for manual eject thread to finish";
         if (_manualEjectThread->wait(10000)) {
+            // Joined, so delete now rather than relying on the thread's own
+            // deleteLater(): the event loop may already be gone by this point.
+            // ~QObject drops the pending DeferredDelete, so this is not a
+            // double free.
             delete _manualEjectThread;
         } else {
+            // Detached. The thread deletes itself through its own finished()
+            // connection, which survives this object's destruction.
             qWarning() << "Manual eject still running at teardown; leaving it to finish detached";
         }
         _manualEjectThread = nullptr;
@@ -2757,8 +2763,13 @@ void ImageWriter::ejectDrive()
         }, Qt::QueuedConnection);
     });
     _manualEjectThread = thread;
+    // Deletion is owned by the thread, not by ImageWriter. The destructor gives
+    // up after 10 s and leaves a slow eject running detached, and that teardown
+    // severs every connection whose receiver is `this` — so a `this`-bound
+    // handler would never reclaim the QThread. A self-owned handler still runs
+    // when the eject finally finishes.
+    connect(thread, &QThread::finished, thread, &QObject::deleteLater);
     connect(thread, &QThread::finished, this, [this, thread]() {
-        thread->deleteLater();
         // A retry may already own the member; only clear our own pointer.
         if (_manualEjectThread == thread)
             _manualEjectThread = nullptr;

--- a/src/imagewriter.cpp
+++ b/src/imagewriter.cpp
@@ -48,6 +48,7 @@
 #include <QTimeZone>
 #include <QNetworkInterface>
 #include <QCoreApplication>
+#include <QPointer>
 #ifndef CLI_ONLY_BUILD
 #include <QQmlContext>
 #include <QWindow>
@@ -502,16 +503,19 @@ ImageWriter::~ImageWriter()
         _cacheManager = nullptr;
     }
 
-    // Wait for a user-triggered eject before teardown; its lambda captures
-    // `this` and reports back via invokeMethod, so it must not outlive us.
+    // Give a user-triggered eject a chance to finish before teardown. Never
+    // terminate() it: killing the thread mid-DiskArbitration call is unsafe,
+    // and deleting a QThread that survived terminate() is a qFatal. If it is
+    // still flushing after the grace period, leave it to finish detached — the
+    // worker only reaches this object through a guarded QPointer, so it cannot
+    // touch a destroyed ImageWriter.
     if (_manualEjectThread) {
         qDebug() << "Waiting for manual eject thread to finish";
-        if (!_manualEjectThread->wait(30000)) {
-            qWarning() << "Manual eject did not finish within 30s, terminating";
-            _manualEjectThread->terminate();
-            _manualEjectThread->wait(2000);
+        if (_manualEjectThread->wait(10000)) {
+            delete _manualEjectThread;
+        } else {
+            qWarning() << "Manual eject still running at teardown; leaving it to finish detached";
         }
-        delete _manualEjectThread;
         _manualEjectThread = nullptr;
     }
 
@@ -2717,7 +2721,10 @@ void ImageWriter::onEjectFinished(bool succeeded)
 
 void ImageWriter::ejectDrive()
 {
-    if (_ejectState == EjectState::EjectInProgress)
+    // The eject result (queued onEjectFinished) can arrive before the worker's
+    // finished() signal, so ejectState alone would let a retry overwrite a
+    // thread that is still winding down — check the thread pointer too.
+    if (_ejectState == EjectState::EjectInProgress || _manualEjectThread)
         return;
 
     // Only regular block devices can be ejected (not fastboot targets)
@@ -2727,7 +2734,11 @@ void ImageWriter::ejectDrive()
     setEjectState(EjectState::EjectInProgress);
 
     const QString device = _dst;
-    _manualEjectThread = QThread::create([this, device]() {
+    // Guard `this` with a QPointer and deliver via the application object: the
+    // destructor does not join a slow eject, so the worker must never touch a
+    // destroyed ImageWriter.
+    QPointer<ImageWriter> self(this);
+    QThread *thread = QThread::create([self, device]() {
         PlatformQuirks::DiskResult result =
             PlatformQuirks::ejectDisk(PlatformQuirks::getEjectDevicePath(device));
         bool succeeded = (result == PlatformQuirks::DiskResult::Success);
@@ -2736,14 +2747,19 @@ void ImageWriter::ejectDrive()
         // even when the target drive ejected fine; only report a definite miss.
         succeeded = (result != PlatformQuirks::DiskResult::InvalidDrive);
 #endif
-        QMetaObject::invokeMethod(this, "onEjectFinished", Qt::QueuedConnection,
-                                  Q_ARG(bool, succeeded));
+        QMetaObject::invokeMethod(QCoreApplication::instance(), [self, succeeded]() {
+            if (self)
+                self->onEjectFinished(succeeded);
+        }, Qt::QueuedConnection);
     });
-    connect(_manualEjectThread, &QThread::finished, this, [this]() {
-        _manualEjectThread->deleteLater();
-        _manualEjectThread = nullptr;
+    _manualEjectThread = thread;
+    connect(thread, &QThread::finished, this, [this, thread]() {
+        thread->deleteLater();
+        // A retry may already own the member; only clear our own pointer.
+        if (_manualEjectThread == thread)
+            _manualEjectThread = nullptr;
     });
-    _manualEjectThread->start();
+    thread->start();
 }
 
 void ImageWriter::setWriteState(WriteState state)

--- a/src/imagewriter.cpp
+++ b/src/imagewriter.cpp
@@ -502,6 +502,19 @@ ImageWriter::~ImageWriter()
         _cacheManager = nullptr;
     }
 
+    // Wait for a user-triggered eject before teardown; its lambda captures
+    // `this` and reports back via invokeMethod, so it must not outlive us.
+    if (_manualEjectThread) {
+        qDebug() << "Waiting for manual eject thread to finish";
+        if (!_manualEjectThread->wait(30000)) {
+            qWarning() << "Manual eject did not finish within 30s, terminating";
+            _manualEjectThread->terminate();
+            _manualEjectThread->wait(2000);
+        }
+        delete _manualEjectThread;
+        _manualEjectThread = nullptr;
+    }
+
     // Ensure any running thread is properly cleaned up
     if (_thread) {
         if (_thread->isRunning()) {
@@ -1037,6 +1050,7 @@ void ImageWriter::startWrite()
     }
 
     setWriteState(WriteState::Preparing);
+    setEjectState(EjectState::EjectIdle);
 
     if (_isFastbootDevice)
     {
@@ -1412,6 +1426,8 @@ void ImageWriter::startWrite()
     connect(_thread, SIGNAL(error(QString)), SLOT(onError(QString)));
     connect(_thread, SIGNAL(finalizing()), SLOT(onFinalizing()));
     connect(_thread, SIGNAL(preparationStatusUpdate(QString)), SLOT(onPreparationStatusUpdate(QString)));
+    connect(_thread, &DownloadThread::ejectStarted, this, &ImageWriter::onEjectStarted);
+    connect(_thread, &DownloadThread::ejectFinished, this, &ImageWriter::onEjectFinished);
     // Ensure cleanup of thread pointer on finish in all paths
     connect(_thread, &QThread::finished, this, [this]() {
         if (_thread)
@@ -2674,6 +2690,60 @@ void ImageWriter::restartWrite(QString reason)
         }
         startWrite();
     }
+}
+
+void ImageWriter::setEjectState(EjectState state)
+{
+    if (_ejectState == state)
+        return;
+
+    _ejectState = state;
+    emit ejectStateChanged();
+}
+
+void ImageWriter::onEjectStarted()
+{
+    setEjectState(EjectState::EjectInProgress);
+}
+
+void ImageWriter::onEjectFinished(bool succeeded)
+{
+    // Ignore a stale result if a new write has already reset the state
+    if (_ejectState != EjectState::EjectInProgress)
+        return;
+
+    setEjectState(succeeded ? EjectState::EjectSucceeded : EjectState::EjectFailed);
+}
+
+void ImageWriter::ejectDrive()
+{
+    if (_ejectState == EjectState::EjectInProgress)
+        return;
+
+    // Only regular block devices can be ejected (not fastboot targets)
+    if (_dst.isEmpty() || _dst.startsWith("fastboot://"))
+        return;
+
+    setEjectState(EjectState::EjectInProgress);
+
+    const QString device = _dst;
+    _manualEjectThread = QThread::create([this, device]() {
+        PlatformQuirks::DiskResult result =
+            PlatformQuirks::ejectDisk(PlatformQuirks::getEjectDevicePath(device));
+        bool succeeded = (result == PlatformQuirks::DiskResult::Success);
+#ifdef Q_OS_WIN
+        // The legacy Windows result can carry an unrelated volume's failure
+        // even when the target drive ejected fine; only report a definite miss.
+        succeeded = (result != PlatformQuirks::DiskResult::InvalidDrive);
+#endif
+        QMetaObject::invokeMethod(this, "onEjectFinished", Qt::QueuedConnection,
+                                  Q_ARG(bool, succeeded));
+    });
+    connect(_manualEjectThread, &QThread::finished, this, [this]() {
+        _manualEjectThread->deleteLater();
+        _manualEjectThread = nullptr;
+    });
+    _manualEjectThread->start();
 }
 
 void ImageWriter::setWriteState(WriteState state)
@@ -4580,6 +4650,8 @@ void ImageWriter::_continueStartWriteAfterCacheVerification(bool cacheIsValid)
     connect(_thread, SIGNAL(error(QString)), SLOT(onError(QString)));
     connect(_thread, SIGNAL(finalizing()), SLOT(onFinalizing()));
     connect(_thread, SIGNAL(preparationStatusUpdate(QString)), SLOT(onPreparationStatusUpdate(QString)));
+    connect(_thread, &DownloadThread::ejectStarted, this, &ImageWriter::onEjectStarted);
+    connect(_thread, &DownloadThread::ejectFinished, this, &ImageWriter::onEjectFinished);
     // Ensure cleanup of thread pointer on finish in all paths
     connect(_thread, &QThread::finished, this, [this]() {
         if (_thread)

--- a/src/imagewriter.h
+++ b/src/imagewriter.h
@@ -66,6 +66,18 @@ public:
     };
     Q_ENUM(WriteState)
 
+    // Progress of the post-write eject, which runs in the background after
+    // success() so the done screen can show a live status instead of the
+    // write blocking on a slow flush. EjectIdle also covers writes where no
+    // eject was requested (auto-eject disabled, fastboot flash).
+    enum class EjectState {
+        EjectIdle,
+        EjectInProgress,
+        EjectSucceeded,
+        EjectFailed
+    };
+    Q_ENUM(EjectState)
+
     // NB: the parent argument is deliberately mandatory (no `= nullptr`).
     // ImageWriter is a QML_SINGLETON whose instance is supplied by main() via
     // setQmlInstance()/create(). Qt's qmlRegisterTypesAndRevisions only honours a
@@ -88,6 +100,7 @@ public:
 #endif
 
     Q_PROPERTY(WriteState writeState READ writeState NOTIFY writeStateChanged)
+    Q_PROPERTY(EjectState ejectState READ ejectState NOTIFY ejectStateChanged)
     Q_PROPERTY(bool isOsListUnavailable READ isOsListUnavailable NOTIFY osListUnavailableChanged)
     Q_PROPERTY(bool screenReaderActive READ isScreenReaderActive NOTIFY screenReaderActiveChanged)
 
@@ -125,6 +138,11 @@ public:
 
     /* Cancel write */
     Q_INVOKABLE void cancelWrite();
+
+    /* Manually eject the written drive (retry after a failed background
+       eject, or first eject when auto-eject is disabled). Runs on a
+       background thread; progress is reported via ejectState. */
+    Q_INVOKABLE void ejectDrive();
 
     /* Skip cache verification and proceed with download */
     Q_INVOKABLE void skipCacheVerification();
@@ -481,6 +499,7 @@ signals:
     void keychainPermissionRequested();
     void keychainPermissionResponseReceived();
     void writeStateChanged();
+    void ejectStateChanged();
     void connectTokenReceived(const QString &token);
     void connectTokenConflictDetected(const QString &token);
     void connectTokenCleared();
@@ -502,6 +521,8 @@ protected slots:
     
     void onSuccess();
     void onError(QString msg);
+    void onEjectStarted();
+    void onEjectFinished(bool succeeded);
     void onFileSelected(QString filename);
     void onCancelled();
     void onFinalizing();
@@ -528,6 +549,8 @@ private:
 #endif
     void setWriteState(WriteState state);
     WriteState writeState() const { return _writeState; }
+    void setEjectState(EjectState state);
+    EjectState ejectState() const { return _ejectState; }
     // Cache management
     CacheManager* _cacheManager;
     bool _waitingForCacheVerification;
@@ -565,6 +588,8 @@ protected:
     DriveListModel _drivelist;
     bool _selectedDeviceValid;
     WriteState _writeState;
+    EjectState _ejectState = EjectState::EjectIdle;
+    QThread *_manualEjectThread = nullptr;
     bool _cancelledDueToDeviceRemoval;
     HWListModel _hwlist;
     OSListModel _oslist;

--- a/src/linux/99-rpiboot.rules
+++ b/src/linux/99-rpiboot.rules
@@ -1,9 +1,21 @@
-# udev rules for Raspberry Pi USB boot devices (Broadcom VID)
-# Grants user access without root for rpiboot functionality in Imager.
+# udev rules for Raspberry Pi USB device access from rpi-imager.
 #
-# Install to /etc/udev/rules.d/ and reload: sudo udevadm control --reload-rules
+# Two device classes need unprivileged (non-root) access:
+#   1. Broadcom boot ROM (VID 0a5c) — a Compute Module / Pi in rpiboot
+#      (USB-boot) mode, which the imager talks to in order to sideload the
+#      fastboot gadget.
+#   2. The fastboot gadget itself (VID 18d1, PID 4e40) — the mode the device
+#      re-enumerates into after sideload, and over which the imager flashes
+#      storage. The gadget borrows Google's VID; PID 4e40 is RPi-specific.
+#
+# Installed to /usr/lib/udev/rules.d/ by the rpi-imager package. For a bare
+# AppImage (which cannot install system files), copy this to /etc/udev/rules.d/
+# and reload:
+#   sudo udevadm control --reload-rules && sudo udevadm trigger
+#
 # SPDX-License-Identifier: Apache-2.0
 
+# ── Boot ROM (rpiboot / USB-boot mode), Broadcom VID ──────────────────────
 # BCM2835 (CM1, Pi Zero)
 SUBSYSTEM=="usb", ATTR{idVendor}=="0a5c", ATTR{idProduct}=="2763", MODE="0666"
 # BCM2836/7 (CM3, Pi 2/3)
@@ -12,3 +24,6 @@ SUBSYSTEM=="usb", ATTR{idVendor}=="0a5c", ATTR{idProduct}=="2764", MODE="0666"
 SUBSYSTEM=="usb", ATTR{idVendor}=="0a5c", ATTR{idProduct}=="2711", MODE="0666"
 # BCM2712 (CM5, Pi 5)
 SUBSYSTEM=="usb", ATTR{idVendor}=="0a5c", ATTR{idProduct}=="2712", MODE="0666"
+
+# ── Fastboot gadget (rpi-fastbootd) ───────────────────────────────────────
+SUBSYSTEM=="usb", ATTR{idVendor}=="18d1", ATTR{idProduct}=="4e40", MODE="0666"

--- a/src/linux/PlatformPackaging.cmake
+++ b/src/linux/PlatformPackaging.cmake
@@ -33,6 +33,12 @@ add_dependencies(${PROJECT_NAME} generate_metainfo)
 
 install(TARGETS ${PROJECT_NAME} DESTINATION bin)
 
+# Install udev rules granting unprivileged USB access to rpiboot/fastboot
+# devices (a CM in rpiboot boot mode, and the fastboot gadget it re-enumerates
+# into). Without these, libusb_open() fails for non-root users and the device
+# silently never appears. Applies to both GUI and CLI builds.
+install(FILES "${CMAKE_CURRENT_LIST_DIR}/99-rpiboot.rules" DESTINATION lib/udev/rules.d)
+
 if(BUILD_CLI_ONLY)
     # CLI-only build: install CLI-specific desktop file (marked as NoDisplay)
     # Icon is still required for AppImage tooling (linuxdeploy) even though NoDisplay=true

--- a/src/linux/file_operations_linux.cpp
+++ b/src/linux/file_operations_linux.cpp
@@ -254,22 +254,45 @@ FileError LinuxFileOperations::OpenDevice(const std::string& path) {
   // Reset direct I/O tracking for new device
   direct_io_attempted_ = false;
   
-  // Use O_DIRECT for block devices to bypass the page cache
-  int flags = O_RDWR;
   bool isBlockDevice = IsBlockDevicePath(path);
-  
-  if (isBlockDevice) {
-    flags |= O_DIRECT;
-    using_direct_io_ = true;
-    direct_io_attempted_ = true;
-  }
-  
-  FileError result = OpenInternal(path.c_str(), flags);
-  
-  // If O_DIRECT fails, fall back to regular I/O
-  if (result != FileError::kSuccess && isBlockDevice && using_direct_io_) {
-    using_direct_io_ = false;
-    result = OpenInternal(path.c_str(), O_RDWR);
+
+  // One open attempt at a given set of extra flags: try O_DIRECT first (block
+  // devices) to bypass the page cache, falling back to buffered I/O if O_DIRECT
+  // is rejected. extraFlags (e.g. O_EXCL) are preserved across that fallback.
+  auto tryOpenWithFlags = [&](int extraFlags) -> FileError {
+    int flags = O_RDWR | extraFlags;
+    if (isBlockDevice) {
+      flags |= O_DIRECT;
+      using_direct_io_ = true;
+      direct_io_attempted_ = true;
+    }
+
+    FileError r = OpenInternal(path.c_str(), flags);
+
+    // If O_DIRECT fails, fall back to regular (buffered) I/O, keeping extraFlags.
+    if (r != FileError::kSuccess && isBlockDevice && using_direct_io_) {
+      using_direct_io_ = false;
+      r = OpenInternal(path.c_str(), O_RDWR | extraFlags);
+    }
+    return r;
+  };
+
+  // Prefer EXCLUSIVE access for block devices (O_EXCL). On Linux, holding a
+  // block device open with O_EXCL stops the kernel from mounting any of its
+  // partitions (mount() returns EBUSY), so udisks/udev cannot auto-mount the
+  // partition we are in the middle of writing. This is the Linux equivalent of
+  // the exclusive share mode used on Windows. The disk is unmounted before we
+  // get here, so O_EXCL should succeed; if it doesn't (something still holds the
+  // device), fall back to a shared open so the write still proceeds.
+  FileError result = tryOpenWithFlags(isBlockDevice ? O_EXCL : 0);
+  opened_exclusive_ = (result == FileError::kSuccess && isBlockDevice);
+  if (result != FileError::kSuccess && isBlockDevice) {
+    int err = last_error_code_;
+    if (err == EBUSY || err == EACCES || err == EPERM) {
+      Log("Exclusive (O_EXCL) open failed with errno " + std::to_string(err) +
+          " - retrying without O_EXCL");
+      result = tryOpenWithFlags(0);
+    }
   }
   
   // Reset async state for new file
@@ -396,15 +419,19 @@ FileError LinuxFileOperations::SetDirectIOEnabled(bool enabled) {
   close(fd_);
   fd_ = -1;
   
-  int flags = O_RDWR;
+  // Preserve exclusive access (O_EXCL) across the reopen if the device was
+  // originally opened exclusively — otherwise toggling direct I/O would drop the
+  // lock and let udisks mount the partition mid-write. See OpenDevice().
+  int exclFlag = opened_exclusive_ ? O_EXCL : 0;
+  int flags = O_RDWR | exclFlag;
   if (enabled && IsBlockDevicePath(savedPath)) {
     flags |= O_DIRECT;
   }
-  
+
   FileError result = OpenInternal(savedPath.c_str(), flags);
   if (result != FileError::kSuccess) {
     if (enabled) {
-      result = OpenInternal(savedPath.c_str(), O_RDWR);
+      result = OpenInternal(savedPath.c_str(), O_RDWR | exclFlag);
       using_direct_io_ = false;
       Log("Failed to enable O_DIRECT, reopened without it");
     }

--- a/src/linux/file_operations_linux.cpp
+++ b/src/linux/file_operations_linux.cpp
@@ -261,18 +261,25 @@ FileError LinuxFileOperations::OpenDevice(const std::string& path) {
   // is rejected. extraFlags (e.g. O_EXCL) are preserved across that fallback.
   auto tryOpenWithFlags = [&](int extraFlags) -> FileError {
     int flags = O_RDWR | extraFlags;
-    if (isBlockDevice) {
+    // Track the O_DIRECT attempt locally: OpenInternal() starts with Close(),
+    // and Close() resets using_direct_io_, so the member is always false by the
+    // time the call returns. Branching on it here would make the buffered
+    // fallback below unreachable, and would also leave using_direct_io_ false
+    // after a *successful* O_DIRECT open.
+    const bool triedDirectIo = isBlockDevice;
+    if (triedDirectIo) {
       flags |= O_DIRECT;
-      using_direct_io_ = true;
       direct_io_attempted_ = true;
     }
 
     FileError r = OpenInternal(path.c_str(), flags);
 
     // If O_DIRECT fails, fall back to regular (buffered) I/O, keeping extraFlags.
-    if (r != FileError::kSuccess && isBlockDevice && using_direct_io_) {
-      using_direct_io_ = false;
+    if (r != FileError::kSuccess && triedDirectIo) {
       r = OpenInternal(path.c_str(), O_RDWR | extraFlags);
+      using_direct_io_ = false;
+    } else {
+      using_direct_io_ = (r == FileError::kSuccess && triedDirectIo);
     }
     return r;
   };
@@ -434,6 +441,18 @@ FileError LinuxFileOperations::SetDirectIOEnabled(bool enabled) {
       result = OpenInternal(savedPath.c_str(), O_RDWR | exclFlag);
       using_direct_io_ = false;
       Log("Failed to enable O_DIRECT, reopened without it");
+    }
+    if (result != FileError::kSuccess && exclFlag != 0) {
+      // The handle was closed above, so anything racing us can claim the device
+      // in that window and every exclusive reopen then fails — which aborts a
+      // write that was already in flight. OpenDevice() degrades to a shared open
+      // in the same situation; do the same here rather than lose the write.
+      result = OpenInternal(savedPath.c_str(), O_RDWR);
+      if (result == FileError::kSuccess) {
+        opened_exclusive_ = false;
+        using_direct_io_ = false;
+        Log("Exclusive reopen failed; continuing with a shared handle");
+      }
     }
     if (result != FileError::kSuccess) {
       return result;

--- a/src/linux/file_operations_linux.h
+++ b/src/linux/file_operations_linux.h
@@ -98,6 +98,10 @@ class LinuxFileOperations : public FileOperations {
   int last_error_code_;
   bool using_direct_io_;
   bool direct_io_attempted_;  // True if O_DIRECT was attempted for this device
+  // True if the device was opened with O_EXCL (exclusive block-device access).
+  // Remembered so reopens (e.g. toggling direct I/O) preserve exclusivity, which
+  // stops udisks/udev from mounting the partition mid-write. See OpenDevice().
+  bool opened_exclusive_ = false;
   
   // io_uring state
   int async_queue_depth_;

--- a/src/mac/platformquirks_macos.mm
+++ b/src/mac/platformquirks_macos.mm
@@ -164,9 +164,20 @@ namespace {
         DADiskUnmount(disk, kDADiskUnmountOptionWhole | kDADiskUnmountOptionForce,
                       callback, &context);
         
+        // Block for up to 50ms per iteration so the asynchronous DiskArbitration
+        // callback (delivered by diskarbitrationd via this run loop) actually has
+        // time to arrive. A zero timeout turns this into a busy-poll that races
+        // through all iterations in a few milliseconds and gives up before a real
+        // unmount completes, so the first attempt on a mounted volume always times
+        // out even though the unmount ultimately succeeds in the background.
+        //
+        // returnAfterSourceHandled must stay false: the callbacks deliberately do
+        // not call CFRunLoopStop() (this is the main run loop shared with Qt), so
+        // the retry count only maps to the intended 60s budget when each iteration
+        // waits out its full 50ms slice rather than returning early on any source.
         int retries = 0;
         while (!context.completed && retries < maxRetries * 100) {
-            CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0.0, true);
+            CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0.05, false);
             retries++;
         }
         

--- a/src/mac/platformquirks_macos.mm
+++ b/src/mac/platformquirks_macos.mm
@@ -70,6 +70,9 @@ namespace {
     struct DiskOpContext {
         PlatformQuirks::DiskResult result = PlatformQuirks::DiskResult::Success;
         bool completed = false;
+        // Signalled by the callback when the operation finishes. Non-null only when a
+        // worker thread is waiting off the run loop; null when we pump inline on main.
+        dispatch_semaphore_t done = nullptr;
     };
     
     PlatformQuirks::DiskResult translateDissenter(DADissenterRef dissenter) {
@@ -107,27 +110,33 @@ namespace {
         }
     }
     
+    // Mark an operation complete and wake any worker thread waiting on it. The
+    // semaphore is only present on the worker-thread path; the main-thread path
+    // polls context.completed via a nested run loop instead.
+    void finishOp(DiskOpContext* ctx, PlatformQuirks::DiskResult result) {
+        ctx->result = result;
+        ctx->completed = true;
+        if (ctx->done) {
+            dispatch_semaphore_signal(ctx->done);
+        }
+    }
+
     void unmountCallback(DADiskRef disk, DADissenterRef dissenter, void* context) {
         (void)disk;
-        DiskOpContext* ctx = static_cast<DiskOpContext*>(context);
-        ctx->result = translateDissenter(dissenter);
-        ctx->completed = true;
+        finishOp(static_cast<DiskOpContext*>(context), translateDissenter(dissenter));
     }
-    
+
     void ejectCallback(DADiskRef disk, DADissenterRef dissenter, void* context) {
         (void)disk;
-        DiskOpContext* ctx = static_cast<DiskOpContext*>(context);
-        ctx->result = translateDissenter(dissenter);
-        ctx->completed = true;
+        finishOp(static_cast<DiskOpContext*>(context), translateDissenter(dissenter));
     }
-    
+
     void ejectUnmountCallback(DADiskRef disk, DADissenterRef dissenter, void* context) {
         DiskOpContext* ctx = static_cast<DiskOpContext*>(context);
         if (dissenter) {
-            ctx->result = translateDissenter(dissenter);
-            ctx->completed = true;
+            finishOp(ctx, translateDissenter(dissenter));
         } else {
-            // Unmount succeeded, now eject
+            // Unmount succeeded, now eject (its callback signals completion).
             DADiskEject(disk, kDADiskEjectOptionDefault, ejectCallback, context);
         }
     }
@@ -196,18 +205,81 @@ namespace {
         return context.result;
     }
 
+    // Worker-thread path: drive the DA session on the main run loop (always pumped
+    // by the app, so callbacks arrive reliably) but block THIS thread on a
+    // semaphore. No nested run loop -> no re-entrant Qt event processing, and the
+    // main thread stays free to keep the UI responsive during a slow unmount.
+    PlatformQuirks::DiskResult runDiskOperationOffMainThread(const char* device,
+                                                              DADiskUnmountCallback callback,
+                                                              int maxRetries) {
+        DiskOpContext context;
+        context.done = dispatch_semaphore_create(0);
+        DiskOpContext* ctxp = &context;   // stable pointer for the async callback
+
+        PLATFORM_LOG_INFO("runDiskOperation: starting operation on %{public}s", device);
+
+        __block DASessionRef session = nullptr;
+        __block DADiskRef disk = nullptr;
+
+        // Create the session and kick off the async unmount on the main thread.
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            session = DASessionCreate(kCFAllocatorDefault);
+            if (!session) {
+                PLATFORM_LOG_ERROR("runDiskOperation: failed to create DA session");
+                finishOp(ctxp, PlatformQuirks::DiskResult::Error);
+                return;
+            }
+            disk = DADiskCreateFromBSDName(kCFAllocatorDefault, session, device);
+            if (!disk) {
+                PLATFORM_LOG_ERROR("runDiskOperation: failed to create disk object for %{public}s", device);
+                finishOp(ctxp, PlatformQuirks::DiskResult::InvalidDrive);
+                return;
+            }
+            DASessionScheduleWithRunLoop(session, CFRunLoopGetMain(), kCFRunLoopDefaultMode);
+            DADiskUnmount(disk, kDADiskUnmountOptionWhole | kDADiskUnmountOptionForce,
+                          callback, ctxp);
+        });
+
+        // Wait off the run loop. Preserves the previous 60s budget (maxRetries * 5s).
+        dispatch_time_t timeout = dispatch_time(DISPATCH_TIME_NOW,
+                                                (int64_t)maxRetries * 5 * NSEC_PER_SEC);
+        bool timedOut = (dispatch_semaphore_wait(context.done, timeout) != 0);
+
+        // Tear down on the main thread. Callbacks are delivered there too, so this is
+        // serialized against them: once this block returns the session is unscheduled
+        // and released, and no further callback can reference `context`.
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            if (session) {
+                DASessionUnscheduleFromRunLoop(session, CFRunLoopGetMain(), kCFRunLoopDefaultMode);
+            }
+            if (disk) {
+                CFRelease(disk);
+            }
+            if (session) {
+                CFRelease(session);
+            }
+        });
+
+        dispatch_release(context.done);   // MRC: dispatch objects aren't auto-managed here
+
+        if (timedOut && !context.completed) {
+            PLATFORM_LOG_ERROR("runDiskOperation: timeout on %{public}s", device);
+            return PlatformQuirks::DiskResult::Busy;
+        }
+        PLATFORM_LOG_INFO("runDiskOperation: completed on %{public}s with result %d",
+                          device, static_cast<int>(context.result));
+        return context.result;
+    }
+
     PlatformQuirks::DiskResult runDiskOperation(const char* device,
                                                  DADiskUnmountCallback callback,
                                                  int maxRetries = 12) {
         if ([NSThread isMainThread]) {
+            // Can't block the main thread on a semaphore — the callback needs this
+            // very run loop — so pump it inline instead.
             return runDiskOperationOnMainRunLoop(device, callback, maxRetries);
         }
-
-        __block PlatformQuirks::DiskResult result = PlatformQuirks::DiskResult::Error;
-        dispatch_sync(dispatch_get_main_queue(), ^{
-            result = runDiskOperationOnMainRunLoop(device, callback, maxRetries);
-        });
-        return result;
+        return runDiskOperationOffMainThread(device, callback, maxRetries);
     }
 }
 

--- a/src/mac/platformquirks_macos.mm
+++ b/src/mac/platformquirks_macos.mm
@@ -135,7 +135,7 @@ namespace {
         }
     }
     
-    // Default timeout: 60 seconds (maxRetries * 100 * 0.05s = 60s with maxRetries=12)
+    // Timeout: maxRetries * 100 iterations * 0.05s, so maxRetries=12 -> 60s.
     // Slow USB drives with many files open may take significant time to unmount
     PlatformQuirks::DiskResult runDiskOperation(const char* device,
                                                 DADiskUnmountCallback callback,
@@ -483,9 +483,14 @@ DiskResult ejectDisk(const QString& device) {
     
     QByteArray bsdNameBytes = bsdName.toUtf8();
     qDebug() << "ejectDisk: ejecting" << bsdNameBytes.constData();
-    
-    // Use the combined unmount+eject callback
-    return runDiskOperation(bsdNameBytes.constData(), ejectUnmountCallback);
+
+    // Use the combined unmount+eject callback. The unmount is what flushes
+    // everything the extract path just wrote out of the page cache, and on a
+    // slow stick that alone can exceed the 60-second default. Give the flush
+    // five minutes; the callers treat the result as best-effort, but timing
+    // out early would let the UI claim the drive is safe to remove while the
+    // kernel is still writing to it.
+    return runDiskOperation(bsdNameBytes.constData(), ejectUnmountCallback, 60);
 }
 
 qreal detectTextScaleFactor()

--- a/src/mac/platformquirks_macos.mm
+++ b/src/mac/platformquirks_macos.mm
@@ -240,7 +240,10 @@ namespace {
                           callback, ctxp);
         });
 
-        // Wait off the run loop. Preserves the previous 60s budget (maxRetries * 5s).
+        // Wait off the run loop. The budget is maxRetries * 5s, matching the
+        // main-run-loop path (maxRetries * 100 iterations * 0.05s). unmountDisk
+        // takes the default 12 -> 60s; ejectDisk passes 60 -> 300s, because the
+        // unmount it performs is what flushes the write out of the page cache.
         dispatch_time_t timeout = dispatch_time(DISPATCH_TIME_NOW,
                                                 (int64_t)maxRetries * 5 * NSEC_PER_SEC);
         bool timedOut = (dispatch_semaphore_wait(context.done, timeout) != 0);

--- a/src/performancestats.cpp
+++ b/src/performancestats.cpp
@@ -473,6 +473,7 @@ QString PerformanceStats::eventTypeName(EventType type)
         
         // Customisation
         case EventType::Customisation: return "customisation";
+        case EventType::CustomisationVerify: return "customisation_verify";
         case EventType::CloudInitGeneration: return "cloudInitGeneration";
         case EventType::FirstRunGeneration: return "firstRunGeneration";
         case EventType::SecureBootSetup: return "secureBootSetup";

--- a/src/performancestats.h
+++ b/src/performancestats.h
@@ -100,6 +100,7 @@ public:
         
         // Customisation
         Customisation,         // Time to apply customisation (config, firstrun, etc.)
+        CustomisationVerify,   // Read-back check that the media kept the customisation files
         CloudInitGeneration,   // Time to generate cloud-init config
         FirstRunGeneration,    // Time to generate firstrun script
         SecureBootSetup,       // Time to set up secure boot files

--- a/src/rpiboot/libusb_transport.cpp
+++ b/src/rpiboot/libusb_transport.cpp
@@ -210,6 +210,32 @@ LibusbTransport::~LibusbTransport()
     }
 }
 
+std::string LibusbTransport::interfaceString() const
+{
+    if (!_handle)
+        return {};
+
+    libusb_config_descriptor* config = nullptr;
+    if (libusb_get_active_config_descriptor(libusb_get_device(_handle), &config) != LIBUSB_SUCCESS
+        || !config)
+        return {};
+
+    std::string result;
+    if (_interface < config->bNumInterfaces
+        && config->interface[_interface].num_altsetting > 0) {
+        uint8_t idx = config->interface[_interface].altsetting[0].iInterface;
+        if (idx != 0) {
+            unsigned char buf[256];
+            int n = libusb_get_string_descriptor_ascii(_handle, idx, buf, sizeof(buf));
+            if (n > 0)
+                result.assign(reinterpret_cast<const char*>(buf), static_cast<size_t>(n));
+        }
+    }
+
+    libusb_free_config_descriptor(config);
+    return result;
+}
+
 bool LibusbTransport::controlTransfer(uint8_t requestType, uint8_t request,
                                        uint16_t wValue, uint16_t wIndex,
                                        std::span<const uint8_t> data,

--- a/src/rpiboot/libusb_transport.h
+++ b/src/rpiboot/libusb_transport.h
@@ -48,7 +48,7 @@ public:
     // Scan for Broadcom devices in USB boot mode
     std::vector<UsbDeviceInfo> scanBootDevices() const;
 
-    // Scan for devices in fastboot mode (Google VID 0x18d1, PID 0x4ee0)
+    // Scan for devices in fastboot mode (Google VID 0x18d1, PID 0x4e40)
     std::vector<UsbDeviceInfo> scanFastbootDevices() const;
 
     // Open a specific device for communication
@@ -97,6 +97,13 @@ public:
     // Diagnostic string built during construction (set_configuration result,
     // claim_interface result).  Included in performance-capture metadata.
     const QString& initDiagnostics() const { return _initDiag; }
+
+    // Read the USB interface string descriptor (iInterface) for the active
+    // interface, decoded as ASCII.  Returns an empty string on failure or if
+    // the interface advertises no string.  Used to positively identify the
+    // RPi fastboot gadget, whose interface descriptor is "fastbootd-provisioner"
+    // (see rpiboot::FASTBOOT_INTERFACE_DESCRIPTOR).
+    std::string interfaceString() const override;
 
 private:
     libusb_device_handle* _handle = nullptr;

--- a/src/rpiboot/rpiboot_types.h
+++ b/src/rpiboot/rpiboot_types.h
@@ -157,6 +157,15 @@ constexpr int     DEFAULT_TIMEOUT_MS    = 3000;
 constexpr uint16_t FASTBOOT_VID         = 0x18d1;       // Google
 constexpr uint16_t FASTBOOT_PID         = 0x4e40;       // RPi Fastboot gadget
 
+// USB interface string descriptor (iInterface) advertised by the RPi
+// fastboot gadget — rpi-fastbootd's FASTBOOTD_INTERFACE_DESCRIPTOR.  The
+// VID/PID above are borrowed from Google, so they cannot distinguish a
+// genuine Pi from a non-Pi device in a colliding fastboot mode; this string
+// can.  Stock Android fastbootd advertises "fastbootd" / "Android Fastboot"
+// instead.  Read at open time (before any fastboot command) to positively
+// identify the gadget.
+constexpr const char* FASTBOOT_INTERFACE_DESCRIPTOR = "fastbootd-provisioner";
+
 // ── Progress callback ──────────────────────────────────────────────────
 // (current, total, status):
 //   - Percentage mode: current/total in [0,100] range (e.g. download progress)

--- a/src/rpiboot/test/mock_usb_transport.h
+++ b/src/rpiboot/test/mock_usb_transport.h
@@ -16,6 +16,7 @@
 #include <cstring>
 #include <deque>
 #include <span>
+#include <string>
 #include <vector>
 
 namespace rpiboot::testing {
@@ -40,6 +41,9 @@ public:
 
     // Set whether the transport reports as open
     void setOpen(bool open) { _isOpen = open; }
+
+    // Set the USB interface string descriptor returned by interfaceString()
+    void setInterfaceString(std::string s) { _interfaceString = std::move(s); }
 
     // Configure a simulated failure on the next N bulk writes
     void failNextBulkWrites(int count) { _failBulkWriteCount = count; }
@@ -127,8 +131,11 @@ public:
 
     bool isOpen() const override { return _isOpen; }
 
+    std::string interfaceString() const override { return _interfaceString; }
+
 private:
     bool _isOpen = true;
+    std::string _interfaceString;
     int _failBulkWriteCount = 0;
     int _failControlCount = 0;
     std::deque<std::vector<uint8_t>> _bulkReadQueue;

--- a/src/rpiboot/test/mock_usb_transport.h
+++ b/src/rpiboot/test/mock_usb_transport.h
@@ -48,6 +48,10 @@ public:
     // Configure a simulated failure on the next N bulk writes
     void failNextBulkWrites(int count) { _failBulkWriteCount = count; }
 
+    // Make the next bulk write report a short (but non-negative) transfer of
+    // `bytes`, as a real USB stack may. Applies once.
+    void shortNextBulkWrite(int bytes) { _shortBulkWriteBytes = bytes; }
+
     // Configure a simulated failure on the next N control transfers
     void failNextControlTransfers(int count) { _failControlCount = count; }
 
@@ -112,6 +116,13 @@ public:
         }
 
         _capturedBulkWrites.emplace_back(data.begin(), data.end());
+
+        if (_shortBulkWriteBytes >= 0) {
+            int n = _shortBulkWriteBytes;
+            _shortBulkWriteBytes = -1;
+            return n;
+        }
+
         return static_cast<int>(data.size());
     }
 
@@ -137,6 +148,7 @@ private:
     bool _isOpen = true;
     std::string _interfaceString;
     int _failBulkWriteCount = 0;
+    int _shortBulkWriteBytes = -1;  // -1 = write everything
     int _failControlCount = 0;
     std::deque<std::vector<uint8_t>> _bulkReadQueue;
     std::vector<std::vector<uint8_t>> _capturedBulkWrites;

--- a/src/rpiboot/usb_transport.h
+++ b/src/rpiboot/usb_transport.h
@@ -11,6 +11,7 @@
 
 #include <cstdint>
 #include <span>
+#include <string>
 
 namespace rpiboot {
 
@@ -52,6 +53,14 @@ public:
     // Bulk IN endpoint address (e.g. 0x82).  Determined from the device's
     // active configuration descriptor; falls back to EP 2 if unknown.
     virtual uint8_t inEndpoint() const { return 0x82; }
+
+    // USB interface string descriptor (iInterface) for the active interface,
+    // decoded as ASCII, or an empty string if unavailable.  Used to
+    // positively identify the RPi fastboot gadget (whose descriptor is
+    // "fastbootd-provisioner").  The default returns empty, so transports
+    // that cannot supply it (e.g. non-USB) fall back to protocol-level
+    // identification.
+    virtual std::string interfaceString() const { return {}; }
 };
 
 } // namespace rpiboot

--- a/src/test/fastboot_protocol_test.cpp
+++ b/src/test/fastboot_protocol_test.cpp
@@ -542,7 +542,7 @@ TEST_CASE("FastbootProtocol download invokes progress callback", "[fastboot][pro
 // Stage
 // ────────────────────────────────────────────────────────────────────────
 
-TEST_CASE("FastbootProtocol stage sends data with stage prefix", "[fastboot][protocol]")
+TEST_CASE("FastbootProtocol stage sends data with the download verb", "[fastboot][protocol]")
 {
     MockUsbTransport mock;
 
@@ -557,11 +557,14 @@ TEST_CASE("FastbootProtocol stage sends data with stage prefix", "[fastboot][pro
     bool ok = fb.stage(mock, std::span<const uint8_t>(payload), nullptr, cancelled);
     CHECK(ok);
 
-    // First bulk write should be the command with "stage:" prefix
+    // stage() intentionally uses the "download:" verb, not "stage:".  On
+    // rpi-fastbootd both map to the same DownloadHandler (device keeps "stage"
+    // only for backward-compat with older imagers), and "download" is the only
+    // one accepted on a restricted TCP data-plane connection.  See
+    // rpi-fastbootd fastboot/device/fastboot_device.cpp BuildCommandMap().
     REQUIRE(!mock.capturedBulkWrites().empty());
     std::string cmd(mock.capturedBulkWrites()[0].begin(), mock.capturedBulkWrites()[0].end());
-    CHECK(cmd.substr(0, 6) == "stage:");
-    CHECK(cmd == "stage:00000100");
+    CHECK(cmd == "download:00000100");
 }
 
 TEST_CASE("FastbootProtocol stage fails when device returns FAIL", "[fastboot][protocol][negative]")
@@ -877,16 +880,17 @@ TEST_CASE("FastbootProtocol writeDeviceFile then readDeviceFile round-trip", "[f
     auto readBack = fb.readDeviceFile(mock, "/boot/firmware/config.txt", cancelled);
     CHECK(readBack == original);
 
-    // Verify all expected commands were sent
+    // Verify all expected commands were sent.  writeDeviceFile stages via
+    // stage(), which uses the "download:" verb (see the stage() test above).
     std::vector<std::string> commands;
     for (const auto& w : mock.capturedBulkWrites()) {
         std::string s(w.begin(), w.end());
         // Filter out raw data payloads (they won't start with known prefixes)
-        if (s.starts_with("stage:") || s.starts_with("oem ") || s == "upload")
+        if (s.starts_with("download:") || s.starts_with("oem ") || s == "upload")
             commands.push_back(s);
     }
     REQUIRE(commands.size() == 4);
-    CHECK(commands[0].starts_with("stage:"));
+    CHECK(commands[0].starts_with("download:"));
     CHECK(commands[1] == "oem download-file /boot/firmware/config.txt");
     CHECK(commands[2] == "oem upload-file /boot/firmware/config.txt");
     CHECK(commands[3] == "upload");

--- a/src/test/fastboot_protocol_test.cpp
+++ b/src/test/fastboot_protocol_test.cpp
@@ -183,6 +183,83 @@ TEST_CASE("FastbootProtocol getVar returns nullopt on FAIL", "[fastboot][protoco
 }
 
 // ────────────────────────────────────────────────────────────────────────
+// Device identification (isRpiFastboot) — guards against a non-Pi device
+// that happens to enumerate as the borrowed 18d1:4e40 VID/PID.
+//
+// Primary signal: the USB interface descriptor "fastbootd-provisioner".
+// Fallback: the RPi-specific "block-devices" getvar.
+// ────────────────────────────────────────────────────────────────────────
+
+TEST_CASE("FastbootProtocol isRpiFastboot true on the fastbootd-provisioner interface descriptor", "[fastboot][protocol][identity]")
+{
+    MockUsbTransport mock;
+    mock.setInterfaceString("fastbootd-provisioner");
+
+    FastbootProtocol fb;
+    CHECK(fb.isRpiFastboot(mock));
+
+    // The descriptor is authoritative — no getvar probe should be sent.
+    CHECK(mock.capturedBulkWrites().empty());
+}
+
+TEST_CASE("FastbootProtocol isRpiFastboot false for a non-Pi interface descriptor with no block-devices", "[fastboot][protocol][identity][negative]")
+{
+    // e.g. a stock Android device that matched the borrowed VID/PID.
+    MockUsbTransport mock;
+    mock.setInterfaceString("Android Fastboot");
+    mock.queueBulkReadResponse(makeResponse("FAIL", "unknown variable"));
+
+    FastbootProtocol fb;
+    CHECK_FALSE(fb.isRpiFastboot(mock));
+}
+
+TEST_CASE("FastbootProtocol isRpiFastboot falls back to block-devices when the descriptor is unavailable", "[fastboot][protocol][identity]")
+{
+    // No interface descriptor (default empty) → protocol-level fallback.
+    MockUsbTransport mock;
+    mock.queueBulkReadResponse(makeResponse("OKAY", "mmcblk0,nvme0n1"));
+
+    FastbootProtocol fb;
+    CHECK(fb.isRpiFastboot(mock));
+
+    // Verify it probed the RPi-specific getvar
+    REQUIRE(!mock.capturedBulkWrites().empty());
+    std::string sent(mock.capturedBulkWrites()[0].begin(), mock.capturedBulkWrites()[0].end());
+    CHECK(sent == "getvar:block-devices");
+}
+
+TEST_CASE("FastbootProtocol isRpiFastboot true for a Pi with an empty block-devices list", "[fastboot][protocol][identity]")
+{
+    // A genuine Pi with no attached storage still OKAYs the getvar (empty
+    // value). Implementing the getvar at all is the positive signal.
+    MockUsbTransport mock;
+    mock.queueBulkReadResponse(makeResponse("OKAY", ""));
+
+    FastbootProtocol fb;
+    CHECK(fb.isRpiFastboot(mock));
+}
+
+TEST_CASE("FastbootProtocol isRpiFastboot false when block-devices FAILs", "[fastboot][protocol][identity][negative]")
+{
+    // Stock Android fastboot/fastbootd does not implement block-devices and
+    // returns FAIL — the device must be rejected.
+    MockUsbTransport mock;
+    mock.queueBulkReadResponse(makeResponse("FAIL", "unknown variable"));
+
+    FastbootProtocol fb;
+    CHECK_FALSE(fb.isRpiFastboot(mock));
+}
+
+TEST_CASE("FastbootProtocol isRpiFastboot false when the transport is dead", "[fastboot][protocol][identity][negative]")
+{
+    // No queued response → bulkRead fails → not identified as a Pi.
+    MockUsbTransport mock;
+
+    FastbootProtocol fb;
+    CHECK_FALSE(fb.isRpiFastboot(mock));
+}
+
+// ────────────────────────────────────────────────────────────────────────
 // Transport failure tests
 // ────────────────────────────────────────────────────────────────────────
 

--- a/src/test/fastboot_protocol_test.cpp
+++ b/src/test/fastboot_protocol_test.cpp
@@ -262,6 +262,32 @@ TEST_CASE("FastbootProtocol identifyRpiFastboot is inconclusive when the transpo
     CHECK(fb.identifyRpiFastboot(mock) == RpiIdentity::Inconclusive);
 }
 
+TEST_CASE("FastbootProtocol rejects a short command write", "[fastboot][protocol][negative]")
+{
+    // A command is a single small ASCII write with no continuation. A positive
+    // but short transfer means the device got a truncated command, so any
+    // response read afterwards is answering something we never sent — even a
+    // queued OKAY must not be accepted.
+    MockUsbTransport mock;
+    mock.shortNextBulkWrite(3);
+    mock.queueBulkReadResponse(makeResponse("OKAY", "mmcblk0"));
+
+    FastbootProtocol fb;
+    CHECK(fb.sendCommand(mock, "getvar:block-devices", 100).type
+          == Response::TransportError);
+}
+
+TEST_CASE("FastbootProtocol short command write is not read as a device denial", "[fastboot][protocol][identity][negative]")
+{
+    // The identity probe must not downgrade a truncated command to
+    // ConfirmedNotPi — that would be cached and strand a genuine Pi.
+    MockUsbTransport mock;
+    mock.shortNextBulkWrite(3);
+
+    FastbootProtocol fb;
+    CHECK(fb.identifyRpiFastboot(mock) == RpiIdentity::Inconclusive);
+}
+
 TEST_CASE("FastbootProtocol reports a dead transport as TransportError, not Fail", "[fastboot][protocol][identity][negative]")
 {
     // The distinction the tri-state identity rests on: a device that refuses

--- a/src/test/fastboot_protocol_test.cpp
+++ b/src/test/fastboot_protocol_test.cpp
@@ -183,26 +183,26 @@ TEST_CASE("FastbootProtocol getVar returns nullopt on FAIL", "[fastboot][protoco
 }
 
 // ────────────────────────────────────────────────────────────────────────
-// Device identification (isRpiFastboot) — guards against a non-Pi device
+// Device identification (identifyRpiFastboot) — guards against a non-Pi device
 // that happens to enumerate as the borrowed 18d1:4e40 VID/PID.
 //
 // Primary signal: the USB interface descriptor "fastbootd-provisioner".
 // Fallback: the RPi-specific "block-devices" getvar.
 // ────────────────────────────────────────────────────────────────────────
 
-TEST_CASE("FastbootProtocol isRpiFastboot true on the fastbootd-provisioner interface descriptor", "[fastboot][protocol][identity]")
+TEST_CASE("FastbootProtocol identifyRpiFastboot confirms on the fastbootd-provisioner interface descriptor", "[fastboot][protocol][identity]")
 {
     MockUsbTransport mock;
     mock.setInterfaceString("fastbootd-provisioner");
 
     FastbootProtocol fb;
-    CHECK(fb.isRpiFastboot(mock));
+    CHECK(fb.identifyRpiFastboot(mock) == RpiIdentity::ConfirmedPi);
 
     // The descriptor is authoritative — no getvar probe should be sent.
     CHECK(mock.capturedBulkWrites().empty());
 }
 
-TEST_CASE("FastbootProtocol isRpiFastboot false for a non-Pi interface descriptor with no block-devices", "[fastboot][protocol][identity][negative]")
+TEST_CASE("FastbootProtocol identifyRpiFastboot denies a non-Pi interface descriptor with no block-devices", "[fastboot][protocol][identity][negative]")
 {
     // e.g. a stock Android device that matched the borrowed VID/PID.
     MockUsbTransport mock;
@@ -210,17 +210,17 @@ TEST_CASE("FastbootProtocol isRpiFastboot false for a non-Pi interface descripto
     mock.queueBulkReadResponse(makeResponse("FAIL", "unknown variable"));
 
     FastbootProtocol fb;
-    CHECK_FALSE(fb.isRpiFastboot(mock));
+    CHECK(fb.identifyRpiFastboot(mock) == RpiIdentity::ConfirmedNotPi);
 }
 
-TEST_CASE("FastbootProtocol isRpiFastboot falls back to block-devices when the descriptor is unavailable", "[fastboot][protocol][identity]")
+TEST_CASE("FastbootProtocol identifyRpiFastboot falls back to block-devices when the descriptor is unavailable", "[fastboot][protocol][identity]")
 {
     // No interface descriptor (default empty) → protocol-level fallback.
     MockUsbTransport mock;
     mock.queueBulkReadResponse(makeResponse("OKAY", "mmcblk0,nvme0n1"));
 
     FastbootProtocol fb;
-    CHECK(fb.isRpiFastboot(mock));
+    CHECK(fb.identifyRpiFastboot(mock) == RpiIdentity::ConfirmedPi);
 
     // Verify it probed the RPi-specific getvar
     REQUIRE(!mock.capturedBulkWrites().empty());
@@ -228,7 +228,7 @@ TEST_CASE("FastbootProtocol isRpiFastboot falls back to block-devices when the d
     CHECK(sent == "getvar:block-devices");
 }
 
-TEST_CASE("FastbootProtocol isRpiFastboot true for a Pi with an empty block-devices list", "[fastboot][protocol][identity]")
+TEST_CASE("FastbootProtocol identifyRpiFastboot confirms a Pi with an empty block-devices list", "[fastboot][protocol][identity]")
 {
     // A genuine Pi with no attached storage still OKAYs the getvar (empty
     // value). Implementing the getvar at all is the positive signal.
@@ -236,27 +236,46 @@ TEST_CASE("FastbootProtocol isRpiFastboot true for a Pi with an empty block-devi
     mock.queueBulkReadResponse(makeResponse("OKAY", ""));
 
     FastbootProtocol fb;
-    CHECK(fb.isRpiFastboot(mock));
+    CHECK(fb.identifyRpiFastboot(mock) == RpiIdentity::ConfirmedPi);
 }
 
-TEST_CASE("FastbootProtocol isRpiFastboot false when block-devices FAILs", "[fastboot][protocol][identity][negative]")
+TEST_CASE("FastbootProtocol identifyRpiFastboot denies when block-devices FAILs", "[fastboot][protocol][identity][negative]")
 {
     // Stock Android fastboot/fastbootd does not implement block-devices and
-    // returns FAIL — the device must be rejected.
+    // returns FAIL — the device answered, and the answer was no.
     MockUsbTransport mock;
     mock.queueBulkReadResponse(makeResponse("FAIL", "unknown variable"));
 
     FastbootProtocol fb;
-    CHECK_FALSE(fb.isRpiFastboot(mock));
+    CHECK(fb.identifyRpiFastboot(mock) == RpiIdentity::ConfirmedNotPi);
 }
 
-TEST_CASE("FastbootProtocol isRpiFastboot false when the transport is dead", "[fastboot][protocol][identity][negative]")
+TEST_CASE("FastbootProtocol identifyRpiFastboot is inconclusive when the transport is dead", "[fastboot][protocol][identity][negative]")
 {
-    // No queued response → bulkRead fails → not identified as a Pi.
+    // No queued response → bulkRead fails → we never heard from the device.
+    // This must NOT be recorded as a denial: a genuine Pi that is still
+    // bringing its gadget up is indistinguishable from this, and caching a
+    // "not a Pi" verdict here would strand it until it is unplugged.
     MockUsbTransport mock;
 
     FastbootProtocol fb;
-    CHECK_FALSE(fb.isRpiFastboot(mock));
+    CHECK(fb.identifyRpiFastboot(mock) == RpiIdentity::Inconclusive);
+}
+
+TEST_CASE("FastbootProtocol reports a dead transport as TransportError, not Fail", "[fastboot][protocol][identity][negative]")
+{
+    // The distinction the tri-state identity rests on: a device that refuses
+    // answers Fail, a device that is not talking yields TransportError.
+    MockUsbTransport mock;
+
+    FastbootProtocol fb;
+    CHECK(fb.sendCommand(mock, "getvar:block-devices", 100).type
+          == Response::TransportError);
+
+    MockUsbTransport refusing;
+    refusing.queueBulkReadResponse(makeResponse("FAIL", "unknown variable"));
+    CHECK(fb.sendCommand(refusing, "getvar:block-devices", 100).type
+          == Response::Fail);
 }
 
 // ────────────────────────────────────────────────────────────────────────

--- a/src/windows/diskpart_util.cpp
+++ b/src/windows/diskpart_util.cpp
@@ -126,6 +126,10 @@ DiskpartResult unmountVolumes(const QByteArray &device, LockedVolumes &locked, T
     {
         if (QByteArray::fromStdString(dev.device).toLower() == canonicalDevice)
         {
+            // How we release the volume after dismount depends on whether Windows
+            // treats this disk as removable. See the branch after dismount below.
+            const bool deviceIsRemovable = dev.isRemovable;
+
             for (const auto &mountpoint : dev.mountpoints)
             {
                 QString driveLetter = QString::fromStdString(mountpoint);
@@ -190,19 +194,50 @@ DiskpartResult unmountVolumes(const QByteArray &device, LockedVolumes &locked, T
                     qDebug() << "Failed to dismount volume" << driveLetter << "- continuing anyway";
                 }
                 
-                // Keep the volume LOCKED and OPEN. Holding the lock stops Windows
-                // from re-mounting the volume (and Explorer from re-grabbing it)
-                // while we wipe the partition table and write the raw image to the
-                // physical drive. Ownership of the handle passes to the caller-owned
-                // LockedVolumes, which releases it once the physical drive is open.
-                //
-                // We deliberately do NOT call DeleteVolumeMountPoint here. Deleting
-                // the mount point permanently removed the drive-letter binding from
-                // the Mount Manager, which stranded card readers that Windows treats
-                // as fixed disks: they reappeared with no drive letter and needed
-                // manual reassignment. Holding the lock keeps the write working while
-                // letting the drive letter return on its own afterwards. See #1665.
-                locked.adopt(hVolume);
+                if (deviceIsRemovable)
+                {
+                    // Removable media (Explorer shows this as a "USB Drive"). Windows
+                    // auto-assigns a drive letter whenever removable media arrives, so
+                    // deleting the mount point does NOT strand the reader — the letter
+                    // returns on its own after the write. Crucially, removing the letter
+                    // also stops Explorer from periodically polling the now-empty volume,
+                    // which is what pops the "Please insert a disk in drive X:" dialog.
+                    // We cannot suppress that dialog any other way: it is raised by
+                    // Explorer (a separate process), so our thread's error mode does not
+                    // apply, and there is nothing left to poll once the letter is gone.
+                    //
+                    // Unlock and close first, then delete the mount point (the old,
+                    // pre-#1665 ordering). Do NOT adopt the handle — we are not holding
+                    // a lock for removable disks.
+                    DeviceIoControl(hVolume, FSCTL_UNLOCK_VOLUME, nullptr, 0, nullptr, 0, &bytesReturned, nullptr);
+                    CloseHandle(hVolume);
+
+                    QString mountPoint = driveLetter + "\\";  // Must end with backslash
+                    if (DeleteVolumeMountPointW(reinterpret_cast<LPCWSTR>(mountPoint.utf16())))
+                    {
+                        qDebug() << "Removed drive letter" << driveLetter << "(removable)";
+                    }
+                    else
+                    {
+                        qDebug() << "Failed to remove drive letter" << driveLetter
+                                 << "error:" << GetLastError() << "- continuing anyway";
+                    }
+                }
+                else
+                {
+                    // Fixed disk (card readers Windows treats as fixed, RMB=0). Keep the
+                    // volume LOCKED and OPEN: holding the lock stops Windows re-mounting
+                    // (and Explorer re-grabbing) the volume while we wipe the partition
+                    // table and write the raw image. Ownership of the handle passes to the
+                    // caller-owned LockedVolumes, released once the physical drive is open.
+                    //
+                    // We must NOT call DeleteVolumeMountPoint for this class: the Mount
+                    // Manager binding is persistent, so deleting it permanently strands the
+                    // drive letter (the reader reappears with no letter). Holding the lock
+                    // keeps the write working while letting the letter return on its own
+                    // after the physical-drive handle closes. See #1665.
+                    locked.adopt(hVolume);
+                }
 
                 // Notify Explorer that the drive has been removed so it releases any
                 // cached handles and stops polling the (now dismounted) volume.
@@ -315,11 +350,16 @@ DiskpartResult cleanDiskFast(const QByteArray &device, TimingCallback timingCall
 
     CloseHandle(hDisk);
 
-    if (success)
-    {
-        // Refresh Windows' view of the partition table now that it has been wiped.
-        rescanDisk(device, timingCallback);
-    }
+    // Deliberately do NOT rescan / notify the shell here. cleanDiskFast runs
+    // mid-prepare (unmount -> clean -> open), while the target volumes are still
+    // locked and their drive letters are still bound (we no longer delete them —
+    // see #1665). rescanDisk ends with SHChangeNotify(SHCNE_MEDIAINSERTED), which
+    // pokes Explorer to poll those letters right after we wiped the partition
+    // table; on a removable card reader the now-empty-but-lettered drive reports
+    // "no media", producing a "Please insert a disk in drive X:" dialog. There is
+    // nothing useful to rescan anyway — the raw write is about to lay down a fresh
+    // partition table, and the real rescan happens after the write completes via
+    // PlatformQuirks::refreshDiskView(). See #1665.
 
     qDebug() << "cleanDiskFast completed:" << (success ? "success" : "failed")
              << "clean=" << cleanElapsed << "ms";

--- a/src/windows/diskpart_util.cpp
+++ b/src/windows/diskpart_util.cpp
@@ -13,6 +13,7 @@
 #include <QElapsedTimer>
 #include <regex>
 #include <chrono>
+#include <utility>
 
 #include <windows.h>
 #include <winioctl.h>
@@ -27,6 +28,45 @@
 #endif
 
 namespace DiskpartUtil {
+
+LockedVolumes::~LockedVolumes()
+{
+    release();
+}
+
+LockedVolumes::LockedVolumes(LockedVolumes&& other) noexcept
+    : _handles(std::move(other._handles))
+{
+    other._handles.clear();
+}
+
+LockedVolumes& LockedVolumes::operator=(LockedVolumes&& other) noexcept
+{
+    if (this != &other)
+    {
+        release();
+        _handles = std::move(other._handles);
+        other._handles.clear();
+    }
+    return *this;
+}
+
+void LockedVolumes::release()
+{
+    for (void* h : _handles)
+    {
+        HANDLE handle = static_cast<HANDLE>(h);
+        if (handle == nullptr || handle == INVALID_HANDLE_VALUE)
+            continue;
+        // Best-effort unlock; closing the handle also releases the lock. The
+        // underlying volume may already be gone (partition table wiped), in
+        // which case this simply fails harmlessly.
+        DWORD bytesReturned;
+        DeviceIoControl(handle, FSCTL_UNLOCK_VOLUME, nullptr, 0, nullptr, 0, &bytesReturned, nullptr);
+        CloseHandle(handle);
+    }
+    _handles.clear();
+}
 
 // Notify Windows Explorer that a drive has changed/been removed
 // This prevents Explorer from showing "Insert a disk" dialogs
@@ -66,7 +106,7 @@ static bool extractDiskNumber(const QByteArray &device, int &diskNumber)
     return true;
 }
 
-DiskpartResult unmountVolumes(const QByteArray &device, TimingCallback timingCallback)
+DiskpartResult unmountVolumes(const QByteArray &device, LockedVolumes &locked, TimingCallback timingCallback)
 {
     QElapsedTimer timer;
     timer.start();
@@ -121,14 +161,14 @@ DiskpartResult unmountVolumes(const QByteArray &device, TimingCallback timingCal
                 // Lock the volume (prevents other processes from accessing it)
                 // Use geometric backoff — Windows 11 25H2+ may hold handles longer
                 {
-                    bool locked = false;
+                    bool lockAcquired = false;
                     int lockDelayMs = 100;
                     for (int attempt = 0; attempt < 8; attempt++)
                     {
                         if (DeviceIoControl(hVolume, FSCTL_LOCK_VOLUME, nullptr, 0, nullptr, 0, &bytesReturned, nullptr))
                         {
                             qDebug() << "Locked volume" << driveLetter;
-                            locked = true;
+                            lockAcquired = true;
                             break;
                         }
                         qDebug() << "FSCTL_LOCK_VOLUME failed for" << driveLetter
@@ -136,7 +176,7 @@ DiskpartResult unmountVolumes(const QByteArray &device, TimingCallback timingCal
                         QThread::msleep(lockDelayMs);
                         lockDelayMs *= 2;
                     }
-                    if (!locked)
+                    if (!lockAcquired)
                         qDebug() << "Could not lock volume" << driveLetter << "- proceeding with dismount anyway";
                 }
                 
@@ -150,28 +190,22 @@ DiskpartResult unmountVolumes(const QByteArray &device, TimingCallback timingCal
                     qDebug() << "Failed to dismount volume" << driveLetter << "- continuing anyway";
                 }
                 
-                // Unlock and close the volume handle BEFORE removing mount point
-                DeviceIoControl(hVolume, FSCTL_UNLOCK_VOLUME, nullptr, 0, nullptr, 0, &bytesReturned, nullptr);
-                CloseHandle(hVolume);
-                
-                // Remove the drive letter assignment using DeleteVolumeMountPoint
-                // This is the KEY step that prevents "Insert a disk" dialogs!
-                // Unlike FSCTL_DISMOUNT_VOLUME which just unmounts the filesystem,
-                // DeleteVolumeMountPoint removes the drive letter entirely so
-                // Windows Explorer won't try to access it after we clean the disk.
-                QString mountPoint = driveLetter + "\\";  // Must end with backslash
-                if (DeleteVolumeMountPointW(reinterpret_cast<LPCWSTR>(mountPoint.utf16())))
-                {
-                    qDebug() << "Removed drive letter" << driveLetter;
-                }
-                else
-                {
-                    DWORD error = GetLastError();
-                    qDebug() << "Failed to remove drive letter" << driveLetter << "error:" << error << "- continuing anyway";
-                }
-                
-                // Notify Explorer that the drive has been removed
-                // This is a secondary notification to help Explorer update its view
+                // Keep the volume LOCKED and OPEN. Holding the lock stops Windows
+                // from re-mounting the volume (and Explorer from re-grabbing it)
+                // while we wipe the partition table and write the raw image to the
+                // physical drive. Ownership of the handle passes to the caller-owned
+                // LockedVolumes, which releases it once the physical drive is open.
+                //
+                // We deliberately do NOT call DeleteVolumeMountPoint here. Deleting
+                // the mount point permanently removed the drive-letter binding from
+                // the Mount Manager, which stranded card readers that Windows treats
+                // as fixed disks: they reappeared with no drive letter and needed
+                // manual reassignment. Holding the lock keeps the write working while
+                // letting the drive letter return on its own afterwards. See #1665.
+                locked.adopt(hVolume);
+
+                // Notify Explorer that the drive has been removed so it releases any
+                // cached handles and stops polling the (now dismounted) volume.
                 notifyShellDriveRemoved(driveLetter);
                 
                 volumesProcessed++;

--- a/src/windows/diskpart_util.h
+++ b/src/windows/diskpart_util.h
@@ -11,6 +11,7 @@
 #include <QObject>
 #include <chrono>
 #include <functional>
+#include <vector>
 
 namespace DiskpartUtil {
 
@@ -22,6 +23,46 @@ enum class VolumeHandling {
 struct DiskpartResult {
     bool success;
     QString errorMessage;
+};
+
+/**
+ * RAII holder for volume handles that have been locked (FSCTL_LOCK_VOLUME) and
+ * dismounted (FSCTL_DISMOUNT_VOLUME) but deliberately kept OPEN.
+ *
+ * Holding the lock keeps Windows from re-mounting (and Explorer from re-grabbing)
+ * the volume while we wipe the partition table and write the raw image to the
+ * physical drive. This replaces the previous approach of calling
+ * DeleteVolumeMountPoint, which permanently removed the drive-letter binding from
+ * the Mount Manager and stranded card readers that Windows treats as fixed disks
+ * (they came back with no drive letter). See issue #1665.
+ *
+ * When these handles are released (unlock + close), Windows re-mounts the volume
+ * once the physical-drive handle is also closed, and — because the Mount Manager
+ * binding was never deleted — the drive letter is reassigned normally.
+ *
+ * The handles are stored as void* so this header does not need <windows.h>.
+ */
+class LockedVolumes {
+public:
+    LockedVolumes() = default;
+    ~LockedVolumes();
+
+    LockedVolumes(LockedVolumes&& other) noexcept;
+    LockedVolumes& operator=(LockedVolumes&& other) noexcept;
+    LockedVolumes(const LockedVolumes&) = delete;
+    LockedVolumes& operator=(const LockedVolumes&) = delete;
+
+    /** Unlock and close every held handle. Safe to call more than once. */
+    void release();
+
+    /** Take ownership of a locked+dismounted, still-open volume handle. */
+    void adopt(void* handle) { _handles.push_back(handle); }
+
+    int count() const { return static_cast<int>(_handles.size()); }
+    bool empty() const { return _handles.empty(); }
+
+private:
+    std::vector<void*> _handles;
 };
 
 /**
@@ -56,13 +97,23 @@ DiskpartResult cleanDisk(const QByteArray &device, std::chrono::milliseconds tim
 DiskpartResult cleanDiskFast(const QByteArray &device, TimingCallback timingCallback = nullptr);
 
 /**
- * Unmount and lock all volumes on a physical drive
+ * Unmount and lock all volumes on a physical drive.
+ *
+ * Each volume is locked (FSCTL_LOCK_VOLUME) and dismounted (FSCTL_DISMOUNT_VOLUME),
+ * then its handle is kept open and adopted into @p locked. The caller must keep
+ * @p locked alive until the physical drive has been opened for writing; releasing
+ * it (or letting it go out of scope) unlocks the volumes so Windows can re-mount
+ * them and reassign their drive letters once the raw write completes.
+ *
+ * Unlike the previous implementation, this does NOT call DeleteVolumeMountPoint,
+ * so the drive-letter binding survives the write. See issue #1665.
  *
  * @param device - Windows physical drive path (e.g., "\\\\.\\PHYSICALDRIVE0")
+ * @param locked - Receives the locked+dismounted volume handles to hold open
  * @param timingCallback - Optional callback for performance event reporting
  * @return DiskpartResult with success status and error message if failed
  */
-DiskpartResult unmountVolumes(const QByteArray &device, TimingCallback timingCallback = nullptr);
+DiskpartResult unmountVolumes(const QByteArray &device, LockedVolumes &locked, TimingCallback timingCallback = nullptr);
 
 /**
  * Force Windows to re-read the partition table and re-enumerate volumes on a

--- a/src/windows/diskpart_util.h
+++ b/src/windows/diskpart_util.h
@@ -97,19 +97,26 @@ DiskpartResult cleanDisk(const QByteArray &device, std::chrono::milliseconds tim
 DiskpartResult cleanDiskFast(const QByteArray &device, TimingCallback timingCallback = nullptr);
 
 /**
- * Unmount and lock all volumes on a physical drive.
+ * Unmount all volumes on a physical drive, using the strategy appropriate to
+ * how Windows classifies the disk:
  *
- * Each volume is locked (FSCTL_LOCK_VOLUME) and dismounted (FSCTL_DISMOUNT_VOLUME),
- * then its handle is kept open and adopted into @p locked. The caller must keep
- * @p locked alive until the physical drive has been opened for writing; releasing
- * it (or letting it go out of scope) unlocks the volumes so Windows can re-mount
- * them and reassign their drive letters once the raw write completes.
+ *  - Fixed disks (card readers Windows treats as RMB=0): each volume is locked
+ *    (FSCTL_LOCK_VOLUME) and dismounted (FSCTL_DISMOUNT_VOLUME), then its handle
+ *    is kept open and adopted into @p locked. The caller must keep @p locked alive
+ *    until the physical drive has been opened for writing; releasing it unlocks the
+ *    volumes so Windows re-mounts them and reassigns their drive letters after the
+ *    write. We must NOT delete the mount point for this class — the Mount Manager
+ *    binding is persistent and deleting it strands the drive letter. See issue #1665.
  *
- * Unlike the previous implementation, this does NOT call DeleteVolumeMountPoint,
- * so the drive-letter binding survives the write. See issue #1665.
+ *  - Removable disks (RMB=1, shown by Explorer as "USB Drive"): each volume is
+ *    dismounted and its mount point deleted (DeleteVolumeMountPoint). Windows
+ *    auto-assigns a letter when removable media arrives, so the letter returns on
+ *    its own after the write; deleting it stops Explorer polling the now-empty
+ *    volume, which otherwise pops a "Please insert a disk in drive X:" dialog.
+ *    Nothing is adopted into @p locked for this class.
  *
  * @param device - Windows physical drive path (e.g., "\\\\.\\PHYSICALDRIVE0")
- * @param locked - Receives the locked+dismounted volume handles to hold open
+ * @param locked - Receives held volume handles for fixed disks (empty for removable)
  * @param timingCallback - Optional callback for performance event reporting
  * @return DiskpartResult with success status and error message if failed
  */

--- a/src/windows/file_operations_windows.cpp
+++ b/src/windows/file_operations_windows.cpp
@@ -280,68 +280,96 @@ FileError WindowsFileOperations::OpenDevice(const std::string& path) {
   // Note: Requires sector-aligned buffers (already done via qMallocAligned with 4096 alignment)
   //
   // FILE_FLAG_OVERLAPPED is always included to enable async I/O via IOCP
-  DWORD flags = FILE_ATTRIBUTE_NORMAL | FILE_FLAG_OVERLAPPED;
-  bool attemptingDirectIO = false;
-  if (isPhysicalDrive) {
-    flags = FILE_FLAG_NO_BUFFERING | FILE_FLAG_WRITE_THROUGH | FILE_FLAG_SEQUENTIAL_SCAN | FILE_FLAG_OVERLAPPED;
-    attemptingDirectIO = true;
-    Log("Using direct I/O (FILE_FLAG_NO_BUFFERING | FILE_FLAG_WRITE_THROUGH | FILE_FLAG_OVERLAPPED) for physical drive");
-  }
-  
-  FileError result = OpenInternal(path, 
-                                  GENERIC_READ | GENERIC_WRITE,
-                                  OPEN_EXISTING,
-                                  flags);
-  if (result != FileError::kSuccess) {
-    // If direct I/O failed, try without it as a fallback
-    if (isPhysicalDrive && attemptingDirectIO) {
-      DWORD directIoError = static_cast<DWORD>(last_error_code_);
-      direct_io_info_.error_code = static_cast<int>(directIoError);
-      
-      std::ostringstream oss;
-      oss << "Direct I/O open failed with error " << directIoError << " (0x" << std::hex << directIoError << ")";
-      Log(oss.str());
-      
-      // Common error codes:
-      // ERROR_INVALID_PARAMETER (87) - alignment/size issues
-      // ERROR_ACCESS_DENIED (5) - permission or volume in use
-      // ERROR_SHARING_VIOLATION (32) - file in use by another process
-      switch (directIoError) {
-        case ERROR_INVALID_PARAMETER:
-          direct_io_info_.error_message = "ERROR_INVALID_PARAMETER: Sector size/alignment issue";
-          Log("  -> ERROR_INVALID_PARAMETER: May be sector size/alignment issue");
-          break;
-        case ERROR_ACCESS_DENIED:
-          direct_io_info_.error_message = "ERROR_ACCESS_DENIED: Volume in use or need admin rights";
-          Log("  -> ERROR_ACCESS_DENIED: Volume may still be in use or need admin rights");
-          break;
-        case ERROR_SHARING_VIOLATION:
-          direct_io_info_.error_message = "ERROR_SHARING_VIOLATION: Another process has device open";
-          Log("  -> ERROR_SHARING_VIOLATION: Another process has the device open");
-          break;
-        default:
-          direct_io_info_.error_message = "Unknown error, fell back to buffered I/O";
-          Log("  -> Falling back to buffered I/O");
-          break;
+  // One open attempt at a given share mode: try direct I/O first (physical
+  // drives), fall back to buffered I/O if the direct-I/O flags are rejected.
+  // Returns the final FileError for this share mode.
+  auto tryOpenAtShareMode = [&](DWORD shareMode) -> FileError {
+    DWORD flags = FILE_ATTRIBUTE_NORMAL | FILE_FLAG_OVERLAPPED;
+    bool attemptingDirectIO = false;
+    if (isPhysicalDrive) {
+      flags = FILE_FLAG_NO_BUFFERING | FILE_FLAG_WRITE_THROUGH | FILE_FLAG_SEQUENTIAL_SCAN | FILE_FLAG_OVERLAPPED;
+      attemptingDirectIO = true;
+      Log("Using direct I/O (FILE_FLAG_NO_BUFFERING | FILE_FLAG_WRITE_THROUGH | FILE_FLAG_OVERLAPPED) for physical drive");
+    }
+
+    FileError r = OpenInternal(path,
+                               GENERIC_READ | GENERIC_WRITE,
+                               OPEN_EXISTING,
+                               flags,
+                               shareMode);
+    if (r != FileError::kSuccess) {
+      // If direct I/O failed, try without it as a fallback
+      if (isPhysicalDrive && attemptingDirectIO) {
+        DWORD directIoError = static_cast<DWORD>(last_error_code_);
+        direct_io_info_.error_code = static_cast<int>(directIoError);
+
+        std::ostringstream oss;
+        oss << "Direct I/O open failed with error " << directIoError << " (0x" << std::hex << directIoError << ")";
+        Log(oss.str());
+
+        // Common error codes:
+        // ERROR_INVALID_PARAMETER (87) - alignment/size issues
+        // ERROR_ACCESS_DENIED (5) - permission or volume in use
+        // ERROR_SHARING_VIOLATION (32) - file in use by another process
+        switch (directIoError) {
+          case ERROR_INVALID_PARAMETER:
+            direct_io_info_.error_message = "ERROR_INVALID_PARAMETER: Sector size/alignment issue";
+            Log("  -> ERROR_INVALID_PARAMETER: May be sector size/alignment issue");
+            break;
+          case ERROR_ACCESS_DENIED:
+            direct_io_info_.error_message = "ERROR_ACCESS_DENIED: Volume in use or need admin rights";
+            Log("  -> ERROR_ACCESS_DENIED: Volume may still be in use or need admin rights");
+            break;
+          case ERROR_SHARING_VIOLATION:
+            direct_io_info_.error_message = "ERROR_SHARING_VIOLATION: Another process has device open";
+            Log("  -> ERROR_SHARING_VIOLATION: Another process has the device open");
+            break;
+          default:
+            direct_io_info_.error_message = "Unknown error, fell back to buffered I/O";
+            Log("  -> Falling back to buffered I/O");
+            break;
+        }
+
+        using_direct_io_ = false;
+        r = OpenInternal(path,
+                         GENERIC_READ | GENERIC_WRITE,
+                         OPEN_EXISTING,
+                         FILE_ATTRIBUTE_NORMAL | FILE_FLAG_SEQUENTIAL_SCAN | FILE_FLAG_OVERLAPPED,
+                         shareMode);
       }
-      
-      using_direct_io_ = false;
-      result = OpenInternal(path, 
-                           GENERIC_READ | GENERIC_WRITE,
-                           OPEN_EXISTING,
-                           FILE_ATTRIBUTE_NORMAL | FILE_FLAG_SEQUENTIAL_SCAN | FILE_FLAG_OVERLAPPED);
+    } else if (isPhysicalDrive) {
+      // Direct I/O succeeded!
+      using_direct_io_ = true;  // Set AFTER OpenInternal (which calls Close() and resets it)
+      direct_io_info_.succeeded = true;
     }
-    
-    if (result != FileError::kSuccess) {
-      std::ostringstream oss;
-      oss << "Failed to open device: " << path << " (error " << last_error_code_ << ")";
-      Log(oss.str());
-      return result;
+    return r;
+  };
+
+  // Prefer EXCLUSIVE write access for physical drives (FILE_SHARE_READ only, no
+  // FILE_SHARE_WRITE). This is what Rufus does (src/drive.c GetHandle): holding
+  // the drive without write-sharing stops the OS volume manager from mounting
+  // the partition we are in the middle of writing. Without it, Windows detects
+  // the freshly-written (but incomplete) filesystem ~1 MB in and pops a
+  // "You need to format the disk in drive X:" prompt. If exclusive access can't
+  // be obtained (something else holds the drive with write access), fall back to
+  // shared write like Rufus does, so the write still proceeds.
+  DWORD preferredShare = isPhysicalDrive ? FILE_SHARE_READ
+                                         : (FILE_SHARE_READ | FILE_SHARE_WRITE);
+  FileError result = tryOpenAtShareMode(preferredShare);
+  if (result != FileError::kSuccess && isPhysicalDrive && preferredShare == FILE_SHARE_READ) {
+    int err = last_error_code_;
+    if (err == ERROR_SHARING_VIOLATION || err == ERROR_ACCESS_DENIED) {
+      Log("Exclusive (unshared-write) open failed with error " + std::to_string(err) +
+          " - retrying with shared write access");
+      result = tryOpenAtShareMode(FILE_SHARE_READ | FILE_SHARE_WRITE);
     }
-  } else if (isPhysicalDrive) {
-    // Direct I/O succeeded!
-    using_direct_io_ = true;  // Set AFTER OpenInternal (which calls Close() and resets it)
-    direct_io_info_.succeeded = true;
+  }
+
+  if (result != FileError::kSuccess) {
+    std::ostringstream oss;
+    oss << "Failed to open device: " << path << " (error " << last_error_code_ << ")";
+    Log(oss.str());
+    return result;
   }
 
   // Enable extended DASD I/O for raw disk access
@@ -657,9 +685,12 @@ FileError WindowsFileOperations::SetDirectIOEnabled(bool enabled) {
     flags = FILE_FLAG_WRITE_THROUGH | FILE_FLAG_SEQUENTIAL_SCAN | FILE_FLAG_OVERLAPPED;
   }
   
-  FileError result = OpenInternal(savedPath, GENERIC_READ | GENERIC_WRITE, OPEN_EXISTING, flags);
+  // Preserve the share mode the device was originally opened with (physical
+  // drives are held with exclusive write access — see OpenDevice).
+  DWORD shareMode = current_share_mode_;
+  FileError result = OpenInternal(savedPath, GENERIC_READ | GENERIC_WRITE, OPEN_EXISTING, flags, shareMode);
   if (result != FileError::kSuccess) {
-    result = OpenInternal(savedPath, GENERIC_READ | GENERIC_WRITE, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL | FILE_FLAG_OVERLAPPED);
+    result = OpenInternal(savedPath, GENERIC_READ | GENERIC_WRITE, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL | FILE_FLAG_OVERLAPPED, shareMode);
     using_direct_io_ = false;
     if (result != FileError::kSuccess) {
       return result;
@@ -731,13 +762,13 @@ FileError WindowsFileOperations::UnlockVolume() {
   return FileError::kSuccess;
 }
 
-FileError WindowsFileOperations::OpenInternal(const std::string& path, DWORD access, DWORD creation, DWORD flags) {
+FileError WindowsFileOperations::OpenInternal(const std::string& path, DWORD access, DWORD creation, DWORD flags, DWORD share_mode) {
   // Close any existing handle
   Close();
 
   handle_ = CreateFileA(path.c_str(),
                         access,
-                        FILE_SHARE_READ | FILE_SHARE_WRITE,
+                        share_mode,
                         nullptr,
                         creation,
                         flags,
@@ -749,6 +780,7 @@ FileError WindowsFileOperations::OpenInternal(const std::string& path, DWORD acc
   }
 
   current_path_ = path;
+  current_share_mode_ = share_mode;
   last_error_code_ = 0;
   return FileError::kSuccess;
 }

--- a/src/windows/file_operations_windows.cpp
+++ b/src/windows/file_operations_windows.cpp
@@ -740,6 +740,19 @@ FileError WindowsFileOperations::SetDirectIOEnabled(bool enabled) {
   if (result != FileError::kSuccess) {
     result = OpenInternal(savedPath, GENERIC_READ | GENERIC_WRITE, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL | FILE_FLAG_OVERLAPPED, shareMode);
     using_direct_io_ = false;
+    if (result != FileError::kSuccess &&
+        shareMode != (FILE_SHARE_READ | FILE_SHARE_WRITE)) {
+      // The handle is already closed, so another process can claim the drive in
+      // that window and every exclusive reopen then fails, aborting a write that
+      // was already in flight. OpenDevice() degrades to a shared open in the same
+      // situation; do the same here rather than lose the write.
+      result = OpenInternal(savedPath, GENERIC_READ | GENERIC_WRITE, OPEN_EXISTING,
+                            FILE_ATTRIBUTE_NORMAL | FILE_FLAG_OVERLAPPED,
+                            FILE_SHARE_READ | FILE_SHARE_WRITE);
+      if (result == FileError::kSuccess) {
+        Log("Exclusive reopen failed; continuing with a shared handle");
+      }
+    }
     if (result != FileError::kSuccess) {
       return result;
     }

--- a/src/windows/file_operations_windows.cpp
+++ b/src/windows/file_operations_windows.cpp
@@ -359,9 +359,33 @@ FileError WindowsFileOperations::OpenDevice(const std::string& path) {
   if (result != FileError::kSuccess && isPhysicalDrive && preferredShare == FILE_SHARE_READ) {
     int err = last_error_code_;
     if (err == ERROR_SHARING_VIOLATION || err == ERROR_ACCESS_DENIED) {
-      Log("Exclusive (unshared-write) open failed with error " + std::to_string(err) +
-          " - retrying with shared write access");
-      result = tryOpenAtShareMode(FILE_SHARE_READ | FILE_SHARE_WRITE);
+      // Something is briefly holding the just-cleaned removable disk with write
+      // access — typically Explorer re-scanning it, an AV, or the search indexer.
+      // Do NOT immediately drop to a shared open: a shared open lets the OS mount
+      // the partition we are about to write and pop a "You need to format the disk"
+      // dialog mid-write. Instead retry the EXCLUSIVE open with geometric backoff
+      // (matching Rufus's DRIVE_ACCESS wait loop) so the transient holder has time
+      // to let go. Only fall back to shared if exclusivity genuinely can't be had.
+      constexpr int kExclusiveRetries = 6;
+      int delayMs = 100;  // 100+200+400+800+1600+3200 ≈ 6.3s total worst case
+      for (int attempt = 1; attempt <= kExclusiveRetries && result != FileError::kSuccess; attempt++) {
+        Log("Exclusive open failed (error " + std::to_string(err) + "), retry " +
+            std::to_string(attempt) + "/" + std::to_string(kExclusiveRetries) +
+            " for exclusive access in " + std::to_string(delayMs) + "ms");
+        Sleep(delayMs);
+        delayMs *= 2;
+        result = tryOpenAtShareMode(FILE_SHARE_READ);
+        if (result == FileError::kSuccess)
+          break;
+        err = last_error_code_;
+        if (err != ERROR_SHARING_VIOLATION && err != ERROR_ACCESS_DENIED)
+          break;  // non-transient error — retrying won't help
+      }
+      if (result != FileError::kSuccess) {
+        Log("Could not obtain exclusive access after retries - falling back to shared "
+            "write access (OS may mount partitions mid-write)");
+        result = tryOpenAtShareMode(FILE_SHARE_READ | FILE_SHARE_WRITE);
+      }
     }
   }
 
@@ -372,12 +396,18 @@ FileError WindowsFileOperations::OpenDevice(const std::string& path) {
     return result;
   }
 
-  // Enable extended DASD I/O for raw disk access
-  DWORD bytes_returned;
-  if (!DeviceIoControl(handle_, FSCTL_ALLOW_EXTENDED_DASD_IO, 
-                       nullptr, 0, nullptr, 0, &bytes_returned, nullptr)) {
-    // This may fail on some systems, but we can continue
-    Log("Warning: FSCTL_ALLOW_EXTENDED_DASD_IO failed, continuing anyway");
+  // Enable extended DASD I/O. This lifts filesystem boundary checks and is only
+  // meaningful for VOLUME handles (\\.\X:). A physical-drive handle already has
+  // unrestricted raw access to every sector, so the IOCTL is not applicable there
+  // and simply returns ERROR_INVALID_FUNCTION — don't issue it (it produced a
+  // spurious "failed" warning on every physical-drive write).
+  if (!isPhysicalDrive) {
+    DWORD bytes_returned;
+    if (!DeviceIoControl(handle_, FSCTL_ALLOW_EXTENDED_DASD_IO,
+                         nullptr, 0, nullptr, 0, &bytes_returned, nullptr)) {
+      // This may fail on some systems, but we can continue
+      Log("Warning: FSCTL_ALLOW_EXTENDED_DASD_IO failed, continuing anyway");
+    }
   }
 
   // Only try to lock volume if this is not a physical drive

--- a/src/windows/file_operations_windows.h
+++ b/src/windows/file_operations_windows.h
@@ -98,6 +98,11 @@ class WindowsFileOperations : public FileOperations {
   int last_error_code_;
   bool using_direct_io_;
   DirectIOInfo direct_io_info_;
+  // Share mode the device was opened with. Physical drives are opened with
+  // exclusive write access (FILE_SHARE_READ only) so the OS cannot mount the
+  // partition mid-write; remembered here so reopens (e.g. toggling direct I/O)
+  // preserve exclusivity. See OpenDevice().
+  DWORD current_share_mode_ = FILE_SHARE_READ | FILE_SHARE_WRITE;
   
   // IOCP async I/O state
   int async_queue_depth_;
@@ -125,7 +130,7 @@ class WindowsFileOperations : public FileOperations {
   
   FileError LockVolume();
   FileError UnlockVolume();
-  FileError OpenInternal(const std::string& path, DWORD access, DWORD creation, DWORD flags = FILE_ATTRIBUTE_NORMAL);
+  FileError OpenInternal(const std::string& path, DWORD access, DWORD creation, DWORD flags = FILE_ATTRIBUTE_NORMAL, DWORD share_mode = FILE_SHARE_READ | FILE_SHARE_WRITE);
   
   static bool IsPhysicalDrivePath(const std::string& path);
   

--- a/src/wizard/DoneStep.qml
+++ b/src/wizard/DoneStep.qml
@@ -19,6 +19,8 @@ WizardStepBase {
     showBackButton: false
     showNextButton: false
     readonly property bool autoEjectEnabled: ImageWriterSingleton.getBoolSetting("eject")
+    readonly property var ejectState: ImageWriterSingleton.ejectState
+    readonly property bool ejectInProgress: ejectState === ImageWriterSingleton.EjectInProgress
     // Use snapshot of customization flags captured when write completed
     // This preserves the state even after token/flags are cleared for security
     readonly property bool anyCustomizationsApplied: (
@@ -238,10 +240,20 @@ WizardStepBase {
             }
             FocusableText {
                 id: ejectInstruction
-                text: root.autoEjectEnabled ? qsTr("The storage device was ejected automatically. You can now remove it safely.") : qsTr("Please eject the storage device before removing it from your computer.")
+                text: {
+                    if (root.ejectState === ImageWriterSingleton.EjectInProgress)
+                        return qsTr("Ejecting the storage device — do not remove it yet…")
+                    if (root.ejectState === ImageWriterSingleton.EjectSucceeded)
+                        return qsTr("The storage device was ejected. You can now remove it safely.")
+                    if (root.ejectState === ImageWriterSingleton.EjectFailed)
+                        return qsTr("The storage device could not be ejected. Close any application still using it, then press Eject.")
+                    // EjectIdle: no eject was requested for this write
+                    return root.autoEjectEnabled ? qsTr("The storage device was ejected automatically. You can now remove it safely.") : qsTr("Please eject the storage device before removing it from your computer.")
+                }
                 font.pointSize: Style.fontSizeDescription
                 font.family: Style.fontFamily
-                color: Style.textDescriptionColor
+                color: root.ejectInProgress || root.ejectState === ImageWriterSingleton.EjectFailed ? Style.formLabelColor : Style.textDescriptionColor
+                font.bold: root.ejectInProgress || root.ejectState === ImageWriterSingleton.EjectFailed
                 Layout.fillWidth: true
                 horizontalAlignment: Text.AlignHCenter
                 wrapMode: Text.WordWrap
@@ -273,10 +285,23 @@ WizardStepBase {
         },
         
         ImButton {
+            id: ejectButton
+            text: qsTr("Eject")
+            accessibleDescription: qsTr("Eject the storage device so it can be removed safely")
+            visible: root.ejectState === ImageWriterSingleton.EjectFailed ||
+                     (root.ejectState === ImageWriterSingleton.EjectIdle && !root.autoEjectEnabled)
+            activeFocusOnTab: true
+            Layout.minimumWidth: Style.buttonWidthMinimum
+            Layout.preferredHeight: Style.buttonHeightStandard
+            onVisibleChanged: root.rebuildFocusOrder()
+            onClicked: ImageWriterSingleton.ejectDrive()
+        },
+
+        ImButton {
             id: writeAnotherButton
             text: qsTr("Write Another")
             accessibleDescription: qsTr("Return to storage selection to write the same image to another storage device")
-            enabled: true
+            enabled: !root.ejectInProgress
             activeFocusOnTab: true
             Layout.minimumWidth: Style.buttonWidthMinimum
             Layout.preferredHeight: Style.buttonHeightStandard
@@ -290,8 +315,8 @@ WizardStepBase {
         ImButtonRed {
             id: finishButton
             text: ImageWriterSingleton.isEmbeddedMode() ? qsTr("Reboot") : CommonStrings.finish
-            accessibleDescription: ImageWriterSingleton.isEmbeddedMode() ? qsTr("Reboot the system to apply changes") : qsTr("Close %1 and exit the application").arg(ImageWriterSingleton.appName())
-            enabled: true
+            accessibleDescription: root.ejectInProgress ? qsTr("Available once the storage device has been ejected") : (ImageWriterSingleton.isEmbeddedMode() ? qsTr("Reboot the system to apply changes") : qsTr("Close %1 and exit the application").arg(ImageWriterSingleton.appName()))
+            enabled: !root.ejectInProgress
             activeFocusOnTab: true
             Layout.minimumWidth: Style.buttonWidthMinimum
             Layout.preferredHeight: Style.buttonHeightStandard
@@ -333,7 +358,12 @@ WizardStepBase {
         
         // Register custom buttons as fourth focus group
         registerFocusGroup("buttons", function() {
-            return [writeAnotherButton, finishButton]
+            var buttons = []
+            if (ejectButton.visible)
+                buttons.push(ejectButton)
+            buttons.push(writeAnotherButton)
+            buttons.push(finishButton)
+            return buttons
         }, 3)
         
         // Ensure focus order is built after custom buttons are fully instantiated

--- a/src/wizard/DoneStep.qml
+++ b/src/wizard/DoneStep.qml
@@ -18,9 +18,10 @@ WizardStepBase {
     title: qsTr("Write complete!")
     showBackButton: false
     showNextButton: false
-    readonly property bool autoEjectEnabled: ImageWriterSingleton.getBoolSetting("eject")
     readonly property var ejectState: ImageWriterSingleton.ejectState
     readonly property bool ejectInProgress: ejectState === ImageWriterSingleton.EjectInProgress
+    // Fastboot targets have no removable medium to eject
+    readonly property bool ejectApplicable: !ImageWriterSingleton.isFastbootDevice()
     // Use snapshot of customization flags captured when write completed
     // This preserves the state even after token/flags are cleared for security
     readonly property bool anyCustomizationsApplied: (
@@ -240,6 +241,7 @@ WizardStepBase {
             }
             FocusableText {
                 id: ejectInstruction
+                visible: root.ejectApplicable
                 text: {
                     if (root.ejectState === ImageWriterSingleton.EjectInProgress)
                         return qsTr("Ejecting the storage device — do not remove it yet…")
@@ -247,8 +249,9 @@ WizardStepBase {
                         return qsTr("The storage device was ejected. You can now remove it safely.")
                     if (root.ejectState === ImageWriterSingleton.EjectFailed)
                         return qsTr("The storage device could not be ejected. Close any application still using it, then press Eject.")
-                    // EjectIdle: no eject was requested for this write
-                    return root.autoEjectEnabled ? qsTr("The storage device was ejected automatically. You can now remove it safely.") : qsTr("Please eject the storage device before removing it from your computer.")
+                    // EjectIdle: no eject ran for this write, so never claim one
+                    // did — instruct the user to eject before removal instead.
+                    return qsTr("Please eject the storage device before removing it from your computer.")
                 }
                 font.pointSize: Style.fontSizeDescription
                 font.family: Style.fontFamily
@@ -288,8 +291,9 @@ WizardStepBase {
             id: ejectButton
             text: qsTr("Eject")
             accessibleDescription: qsTr("Eject the storage device so it can be removed safely")
-            visible: root.ejectState === ImageWriterSingleton.EjectFailed ||
-                     (root.ejectState === ImageWriterSingleton.EjectIdle && !root.autoEjectEnabled)
+            visible: root.ejectApplicable &&
+                     (root.ejectState === ImageWriterSingleton.EjectFailed ||
+                      root.ejectState === ImageWriterSingleton.EjectIdle)
             activeFocusOnTab: true
             Layout.minimumWidth: Style.buttonWidthMinimum
             Layout.preferredHeight: Style.buttonHeightStandard
@@ -353,7 +357,7 @@ WizardStepBase {
         
         // Register eject instruction as third focus group
         registerFocusGroup("eject", function() {
-            return [ejectInstruction]
+            return ejectInstruction.visible ? [ejectInstruction] : []
         }, 2)
         
         // Register custom buttons as fourth focus group

--- a/src/wizard/IfAndFeaturesCustomizationStep.qml
+++ b/src/wizard/IfAndFeaturesCustomizationStep.qml
@@ -47,7 +47,13 @@ WizardStepBase {
     content: [
         ScrollView {
             id: ifAndFeatScroll
-            anchors.fill: parent
+            // Size explicitly instead of anchors.fill: an anchored height is not an
+            // "explicit" height as far as QQuickItem is concerned, so the holder's
+            // implicitHeight below would propagate up through ScrollView's implicit
+            // size, transiently resize this view and feed back into availableHeight
+            // — a binding loop.
+            width: parent.width
+            height: parent.height
             clip: true
             ScrollBar.vertical.policy: ScrollBar.AsNeeded
             rightPadding: 20

--- a/src/wizard/IfAndFeaturesCustomizationStep.qml
+++ b/src/wizard/IfAndFeaturesCustomizationStep.qml
@@ -51,9 +51,22 @@ WizardStepBase {
             clip: true
             ScrollBar.vertical.policy: ScrollBar.AsNeeded
             rightPadding: 20
+
+            // Holder that is at least as tall as the viewport so the content can be
+            // vertically centred when it fits, and scroll when it doesn't. Anchoring
+            // verticalCenter directly inside the ScrollView's flickable would be a
+            // no-op (the flickable content item is sized to the content itself).
+            Item {
+                id: ifAndFeatContentHolder
+                width: ifAndFeatScroll.availableWidth
+                implicitWidth: ifAndFeatScroll.availableWidth
+                implicitHeight: Math.max(ifAndFeatScroll.availableHeight, scrollContent.implicitHeight)
+
             ColumnLayout {
                 id: scrollContent
-                width: ifAndFeatScroll.availableWidth
+                anchors.left: parent.left
+                anchors.right: parent.right
+                anchors.verticalCenter: parent.verticalCenter
                 spacing: Style.stepContentSpacing
 
                 // === Interfaces ===
@@ -165,6 +178,7 @@ WizardStepBase {
                         }
                     }
                 }
+            }
             }
         }
     ]

--- a/src/wizard/RemoteAccessStep.qml
+++ b/src/wizard/RemoteAccessStep.qml
@@ -31,14 +31,24 @@ WizardStepBase {
         clip: true
         ScrollBar.vertical.policy: ScrollBar.AsNeeded
         
+        // Holder that is at least as tall as the viewport so the content can be
+        // vertically centred when it fits, and scroll when it doesn't. Anchoring
+        // verticalCenter directly inside the ScrollView's flickable would be a
+        // no-op (the flickable content item is sized to the content itself).
+        Item {
+            id: sshContentHolder
+            width: sshScroll.availableWidth
+            implicitWidth: sshScroll.availableWidth
+            implicitHeight: Math.max(sshScroll.availableHeight, sshContentColumn.implicitHeight)
+
         ColumnLayout {
+            id: sshContentColumn
             anchors.left: parent.left
             anchors.right: parent.right
             anchors.verticalCenter: parent.verticalCenter
             anchors.margins: Style.sectionPadding
             spacing: Style.spacingSmall  // Reduced spacing to trim whitespace under subtitle
-            width: sshScroll.availableWidth
-            
+
             WizardSectionContainer {
                 // Replace checkbox with an option pill and help link
                 ImOptionPill {
@@ -103,6 +113,7 @@ WizardStepBase {
                     }
                 }
             }
+        }
         }
     }
     ]

--- a/src/wizard/RemoteAccessStep.qml
+++ b/src/wizard/RemoteAccessStep.qml
@@ -27,7 +27,13 @@ WizardStepBase {
     content: [
     ScrollView {
         id: sshScroll
-        anchors.fill: parent
+        // Size explicitly instead of anchors.fill: an anchored height is not an
+        // "explicit" height as far as QQuickItem is concerned, so the holder's
+        // implicitHeight below would propagate up through ScrollView's implicit
+        // size, transiently resize this view and feed back into availableHeight
+        // — a binding loop.
+        width: parent.width
+        height: parent.height
         clip: true
         ScrollBar.vertical.policy: ScrollBar.AsNeeded
         

--- a/src/wizard/WifiCustomizationStep.qml
+++ b/src/wizard/WifiCustomizationStep.qml
@@ -198,7 +198,13 @@ WizardStepBase {
     content: [
     ScrollView {
         id: wifiScroll
-        anchors.fill: parent
+        // Size explicitly instead of anchors.fill: an anchored height is not an
+        // "explicit" height as far as QQuickItem is concerned, so the holder's
+        // implicitHeight below would propagate up through ScrollView's implicit
+        // size, transiently resize this view and feed back into availableHeight
+        // — a binding loop.
+        width: parent.width
+        height: parent.height
         clip: true
         ScrollBar.vertical.policy: ScrollBar.AsNeeded
 

--- a/src/wizard/WifiCustomizationStep.qml
+++ b/src/wizard/WifiCustomizationStep.qml
@@ -225,13 +225,23 @@ WizardStepBase {
             }
         }
 
+        // Holder that is at least as tall as the viewport so the content can be
+        // vertically centred when it fits, and scroll when it doesn't. Anchoring
+        // verticalCenter directly inside the ScrollView's flickable would be a
+        // no-op (the flickable content item is sized to the content itself).
+        Item {
+            id: wifiContentHolder
+            width: wifiScroll.availableWidth
+            implicitWidth: wifiScroll.availableWidth
+            implicitHeight: Math.max(wifiScroll.availableHeight, wifiContentColumn.implicitHeight)
+
         ColumnLayout {
+            id: wifiContentColumn
             anchors.left: parent.left
             anchors.right: parent.right
             anchors.verticalCenter: parent.verticalCenter
             anchors.margins: Style.sectionPadding
             spacing: Style.stepContentSpacing
-            width: wifiScroll.availableWidth
 
             WizardSectionContainer {
                 RowLayout {
@@ -380,6 +390,7 @@ WizardStepBase {
                     }
                 }
             }
+        }
         }
     }
     ]

--- a/src/wizard/WritingStep.qml
+++ b/src/wizard/WritingStep.qml
@@ -13,7 +13,6 @@ import QtQuick.Window
 import "../qmlcomponents"
 
 import RpiImager
-import ImageOptions
 
 WizardStepBase {
     id: root

--- a/src/wizard/components/SshKeyManager.qml
+++ b/src/wizard/components/SshKeyManager.qml
@@ -166,23 +166,31 @@ ColumnLayout {
                 id: keyRow
                 Layout.fillWidth: true
                 spacing: Style.spacingSmall
-                
+
+                // Model data injected by the Repeater. These must be declared as
+                // required properties under `pragma ComponentBehavior: Bound`;
+                // otherwise the implicitly-injected context properties resolve to
+                // undefined in compiled bindings, leaving the key text blank and
+                // the Remove button inert. See issue #1664.
+                required property int index
+                required property var modelData
+
                 // Accessibility for the row as a list item
                 Accessible.role: Accessible.ListItem
                 Accessible.name: {
                     // Provide full key info for screen readers
-                    var keyText = modelData
+                    var keyText = keyRow.modelData
                     var parts = keyText.split(/\s+/)
                     if (parts.length >= 2) {
                         var keyType = parts[0]
                         var comment = parts.length > 2 ? parts.slice(2).join(" ") : ""
                         if (comment) {
-                            return qsTr("SSH key %1: %2, %3").arg(index + 1).arg(keyType).arg(comment)
+                            return qsTr("SSH key %1: %2, %3").arg(keyRow.index + 1).arg(keyType).arg(comment)
                         } else {
-                            return qsTr("SSH key %1: %2").arg(index + 1).arg(keyType)
+                            return qsTr("SSH key %1: %2").arg(keyRow.index + 1).arg(keyType)
                         }
                     }
-                    return qsTr("SSH key %1").arg(index + 1)
+                    return qsTr("SSH key %1").arg(keyRow.index + 1)
                 }
                 Accessible.ignored: false
                 Accessible.focusable: ImageWriterSingleton ? ImageWriterSingleton.screenReaderActive : false
@@ -192,8 +200,9 @@ ColumnLayout {
                 // Key text (truncated for display)
                 Text {
                     Layout.fillWidth: true
+                    Layout.maximumWidth: parent ? parent.width - 100 : 500
                     text: {
-                        var keyText = modelData
+                        var keyText = keyRow.modelData
                         // Parse SSH key format: keytype keydata [comment]
                         var parts = keyText.split(/\s+/)
                         if (parts.length >= 2) {
@@ -234,14 +243,14 @@ ColumnLayout {
                 ImButton {
                     text: qsTr("Remove")
                     Layout.minimumWidth: 80
-                    onClicked: root.removeKey(index)
+                    onClicked: root.removeKey(keyRow.index)
                     accessibleDescription: {
-                        var keyText = modelData
+                        var keyText = keyRow.modelData
                         var parts = keyText.split(/\s+/)
                         if (parts.length > 2) {
                             return qsTr("Remove SSH key: %1").arg(parts.slice(2).join(" "))
                         }
-                        return qsTr("Remove SSH key %1").arg(index + 1)
+                        return qsTr("Remove SSH key %1").arg(keyRow.index + 1)
                     }
                 }
             }


### PR DESCRIPTION
## Problem

After the DiskArbitration wait was repaired in #118 (v2.0.11-unraid.1), `ejectDisk()` genuinely blocks until macOS finishes the eject. On macOS the unmount inside it is what flushes the freshly written files out of the page cache, so it runs for tens of seconds on a real stick. The extract path ejected **before** emitting `success()`, so the UI froze on "Finalising…" at 100% — both testers force-quit the app there. (In v2.0.11-unraid.0 the broken zero-second wait made eject an accidental no-op, which is why this never showed before.)

Measured with the exact `runDiskOperation()` code against hdiutil FAT32 disks: 6.5 s to eject an empty 64 MB volume, 10.1 s after writing 250 MB / 1000 files. A slow physical stick with a full release plausibly exceeded the old 60 s cap.

## Fix

**47451509 — eject robustness**
- Raise the eject timeout to five minutes (unmount keeps 60 s). Timing out mid-flush would let the done screen claim the drive is safe to remove while the kernel is still writing to it.

**a9178543 — background eject with live status**
- Every write path now emits `ejectStarted()` → `success()` immediately, then performs the eject on the worker thread. The done screen appears the moment the write finishes.
- New `ImageWriter.ejectState` property (`Idle / InProgress / Succeeded / Failed`) drives a live status line on the done screen: "do not remove it yet…" → "safe to remove", or a failure message.
- An **Eject** button appears when auto-eject is disabled or the background eject failed, backed by a new `ejectDrive()` invokable running on a disposable thread.
- Finish and Write Another are disabled while an eject is in flight so the user can't quit mid-flush.
- Windows' legacy eject result is treated as best-effort (only a definite invalid-drive reports failure), preserving the prior intent of ignoring its unrelated-volume errors.

**ba37eb92, e2cc6b51 — review-round fixes on the eject work**
- Do not terminate the manual eject thread; a retry can no longer clobber a thread still winding down; `EjectIdle` never claims an eject that did not run.
- The detached eject thread now reclaims itself. The destructor gives up after 10 s and leaves a slow eject running, and that same teardown severs any `this`-bound handler — so deletion belongs to the thread, not to `ImageWriter`.
- The Linux partition-node wait stops on cancel instead of falling through to `mount`.

**96f717da — carried fixes for the 2.0.11-rc2 preview merge**

`2569eb38` previewed raspberrypi/rpi-imager#1674. Reviewing that merge surfaced defects in the imported commits; #1674 is still open at the SHA we imported and `upstream/main` has not fixed any of them, so eight are carried here. Two are regressions against `upstream/main` rather than pre-existing bugs: ZSTD sentinel handling (a streaming-compressed `.img.zst` was rejected as too large for the stick) and the exclusive direct-I/O reopen, which lost its shared-access fallback and can abort an in-flight write. The rest: `std::terminate()` on a failed flush during `~DeviceWrapper()`, a cancelled write reported as success, a customisation failure skipping the Windows disk-view refresh, unguarded fastboot erase steps, and a fastboot identity probe that treated "no answer" as "not a Pi" and cached it permanently.

Kept as a separate commit so the carried patches stay identifiable when #1674 lands and we re-merge.

**8fe4f5c1 — reject short fastboot command writes**

`bulkWrite()` returns the transfer count, and the three raw command writes only checked for a negative result, so a positive short write was accepted and the code went on to read a response to a partly-sent command. Fixed in `sendCommandCapture()`, `sendData()` and `upload()`; the payload loop in `sendData()` is deliberately unchanged, since it resumes correctly by transferred count.

This matters twice over for the identity probe: a truncated command previously read as a device *denial*, which `DriveListModelPollThread` would cache — stranding a genuine Pi by a second route into the same failure the commit above fixes.

## Testing

- All touched C++ TUs syntax-checked against Qt headers; QML linted (only pre-existing unqualified-access warnings).
- Standalone reproduction of the DA eject verified callback delivery and timings on macOS.
- Linux QEMU e2e only waits for the "Write complete!" heading, which now appears sooner — assertions unaffected.
- All five checks green on `8fe4f5c1` before tagging.
- The `RpiIdentity` and short-write logic was verified by *executing* its assertions against the real protocol code, not only by compiling them — see the caveat below.
- **Needs real-hardware verification**: RC tag `v2.0.11-unraid.2-rc.5` (pre-release, so it will not carry the "Latest" badge).
  - **macOS** — the original bug: write a stick, confirm the done screen appears instantly and the eject status flips to "safe to remove". Unchanged since rc.1, so a pass here re-confirms rather than tests something new.
  - **Windows** — changed in `96f717da`. The exclusive-reopen fallback is new; confirm a normal write still completes and the drive keeps its letter afterwards.
  - **Linux** — changed in `96f717da`. The O_DIRECT open path is new; confirm a normal write still completes.

  The Windows and Linux items matter more than the macOS one: those paths changed in `96f717da` and have only been exercised by compilation and the QEMU journey, not by a real stick.

### Caveat on CI coverage

`BUILD_TESTING` defaults to `OFF` (`src/CMakeLists.txt:580`) and neither `build.yml` nor `release.yml` sets it, so **the unit tests are not compiled or run in CI**. A green run means the application builds on three platforms; it says nothing about the test suite.

The fastboot test changes here were therefore verified out-of-band: a probe linking the real `fastboot_protocol.cpp` and executing every assertion the Catch2 file makes (all pass), plus a parse of the test file itself. Worth fixing properly in its own PR rather than inside an RC — turning `BUILD_TESTING` on will likely surface failures in suites that have not been run in a while.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ejection progress, status reporting, and manual retry controls after writing completes.
  * Added support for formatting Raspberry Pi fastboot devices and improved device identification.
  * Enabled unprivileged access to supported Raspberry Pi USB boot devices.

* **Bug Fixes**
  * Improved automatic ejection, mounting, and success reporting across platforms.
  * Added post-write verification for customized files.
  * Improved data flushing, device access, and partition detection reliability.
  * Refined customization screen scrolling, centering, and accessibility behavior.
  * Improved archive size detection and repository URL validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


Related to DST-177


