### PR TITLE
fix(eject): carry the upstream review fixes into the fork

### DIFF
--- a/src/downloadthread.cpp
+++ b/src/downloadthread.cpp
@@ -2069,13 +2069,7 @@ void DownloadThread::_performEject()
     QString ejectPath = PlatformQuirks::getEjectDevicePath(_filename);
     PlatformQuirks::DiskResult result = PlatformQuirks::ejectDisk(ejectPath);
 
-    bool succeeded = (result == PlatformQuirks::DiskResult::Success);
-#ifdef Q_OS_WIN
-    // The legacy Windows implementation walks every drive letter, so its
-    // result can carry an unrelated volume's failure even when the target
-    // drive ejected fine. Only report a definite miss.
-    succeeded = (result != PlatformQuirks::DiskResult::InvalidDrive);
-#endif
+    const bool succeeded = (result == PlatformQuirks::DiskResult::Success);
 
     qDebug() << "Background eject finished for" << ejectPath << "succeeded:" << succeeded;
     emit ejectFinished(succeeded);

--- a/src/imagewriter.cpp
+++ b/src/imagewriter.cpp
@@ -2762,12 +2762,7 @@ void ImageWriter::ejectDrive()
     QThread *thread = QThread::create([self, device]() {
         PlatformQuirks::DiskResult result =
             PlatformQuirks::ejectDisk(PlatformQuirks::getEjectDevicePath(device));
-        bool succeeded = (result == PlatformQuirks::DiskResult::Success);
-#ifdef Q_OS_WIN
-        // The legacy Windows result can carry an unrelated volume's failure
-        // even when the target drive ejected fine; only report a definite miss.
-        succeeded = (result != PlatformQuirks::DiskResult::InvalidDrive);
-#endif
+        const bool succeeded = (result == PlatformQuirks::DiskResult::Success);
         QMetaObject::invokeMethod(QCoreApplication::instance(), [self, succeeded]() {
             if (self)
                 self->onEjectFinished(succeeded);

--- a/src/wizard/DoneStep.qml
+++ b/src/wizard/DoneStep.qml
@@ -246,7 +246,7 @@ WizardStepBase {
                     if (root.ejectState === ImageWriterSingleton.EjectInProgress)
                         return qsTr("Ejecting the storage device — do not remove it yet…")
                     if (root.ejectState === ImageWriterSingleton.EjectSucceeded)
-                        return qsTr("The storage device was ejected. You can now remove it safely.")
+                        return qsTr("The storage device was ejected automatically. You can now remove it safely.")
                     if (root.ejectState === ImageWriterSingleton.EjectFailed)
                         return qsTr("The storage device could not be ejected. Close any application still using it, then press Eject.")
                     // EjectIdle: no eject ran for this write, so never claim one


### PR DESCRIPTION
Ports the two review fixes from [raspberrypi/rpi-imager#1685](https://github.com/raspberrypi/rpi-imager/pull/1685) into the fork, so the two trees agree on these lines. Whenever #1685 lands upstream, the next merge is a no-op here instead of a conflict.

**`DoneStep.qml`** — the `EjectSucceeded` case goes back to the original string:

> The storage device was ejected automatically. You can now remove it safely.

That exact source string is already in all 27 `.ts` files. The reworded version reset the success case to untranslated in every language. The cost is that "automatically" is not strictly true when the user pressed **Eject** themselves — Tom accepted that as the cheaper of the two.

**`imagewriter.cpp`, `downloadthread.cpp`** — report an eject as successful only on `DiskResult::Success`.

The comment justifying the `Q_OS_WIN` leniency was wrong. [`processDriveLetter()`](src/windows/platformquirks_windows.cpp) returns `Success` both when a drive letter cannot be opened and when its device number does not match the target, so an unrelated volume can never contribute a `Busy` or an `Error`. Every non-`Success` result already comes from a volume on the drive being ejected — which made the old check pure masking: a locked volume on the target drive reported "safe to remove", the exact claim this feature exists to stop being a lie.

---

**Stacked on #124** — base it there rather than `main` so it does not conflict with the upstream merge in the same two files. GitHub retargets this to `main` automatically once #124 lands.
